### PR TITLE
Improve mobile UI

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -4,7 +4,12 @@ const { faculty } = Astro.props;
 ---
 <a href={`/faculty/${faculty.id}`} class="block">
   <article class="card" view-transition-name={`card-${faculty.id}`}>
-    <img src={faculty.photo} alt={`Photo of ${faculty.name}`} loading="lazy" class="w-full h-auto rounded mb-2" />
+    <img
+      src={faculty.photo}
+      alt={`Photo of ${faculty.name}`}
+      loading="lazy"
+      class="w-full h-40 md:h-48 object-cover rounded mb-2"
+    />
     <h3 class="text-lg font-semibold">{faculty.name}</h3>
     <p class="text-sm text-gray-600 dark:text-gray-300">{faculty.dept}</p>
     <div class="space-y-1 mt-1">

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -11,14 +11,14 @@ const RatingWidget: FC<Props> = ({ rating, showValue = false }) => {
   return (
     <div
       aria-label={`Average rating ${rating}`}
-      className="flex items-center gap-1"
+      className="flex items-center gap-1 text-yellow-500 text-sm md:text-base"
     >
       {[1, 2, 3, 4, 5].map((i) => (
         <motion.span key={i} initial={{ scale: 0 }} animate={{ scale: 1 }}>
           {i <= Math.round(rating) ? '★' : '☆'}
         </motion.span>
       ))}
-      {showValue && <span className="text-sm">{rating.toFixed(1)}</span>}
+      {showValue && <span className="ml-1">{rating.toFixed(1)}</span>}
     </div>
   );
 };

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -14,7 +14,7 @@ const { title = 'Faculty Ranker' } = Astro.props;
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+4" />
   <script type="module" src="/viewTransitions.js" />
 </head>
-<body class="min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
   <header class="p-4 text-center text-2xl font-bold">Faculty Ranker</header>
   <main class="container mx-auto p-4"><slot /></main>
 </body>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,4 +3,6 @@
 @tailwind utilities;
 
 /* Critical styles for cards */
-.card { @apply bg-white dark:bg-gray-800 shadow rounded p-4 transition-shadow; }
+.card {
+  @apply bg-white dark:bg-gray-800 shadow rounded p-4 transition-shadow hover:shadow-lg animate-fade;
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -2,7 +2,17 @@ module.exports = {
   darkMode: 'class',
   content: ['./src/**/*.{astro,html,js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      keyframes: {
+        fade: {
+          '0%': { opacity: '0', transform: 'scale(0.95)' },
+          '100%': { opacity: '1', transform: 'scale(1)' },
+        },
+      },
+      animation: {
+        fade: 'fade 0.3s ease-in-out',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- tweak rating widget color and sizing
- refine faculty card image sizing
- add fade-in animation for cards
- introduce gradient background
- define custom Tailwind animation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684aeef18230832f9af82c540b46fc76