### PR TITLE
Fix faculty card images and improve mobile grid

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -8,7 +8,7 @@ const { faculty } = Astro.props;
       src={faculty.photo}
       alt={`Photo of ${faculty.name}`}
       loading="lazy"
-      class="w-full h-40 md:h-48 object-cover rounded mb-2"
+      class="w-full h-auto max-h-40 md:max-h-48 object-contain rounded mb-2"
     />
     <h3 class="text-lg font-semibold">{faculty.name}</h3>
     <p class="text-sm text-gray-600 dark:text-gray-300">{faculty.dept}</p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ let filteredIds = faculty.map(f => f.id);
 ---
 <Base>
   <div class="mb-4" id="search"><SearchBar data={faculty} onFilter={(ids)=>filteredIds = ids} client:load /></div>
-  <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
     {paginate(faculty.filter(f=>filteredIds.includes(f.id)), page).map(f => (
       <FacultyCard faculty={f} />
     ))}

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -15,7 +15,7 @@ if (page < 1 || page > pages) {
 }
 ---
 <Base title={`Page ${page} - Faculty Ranker`}>
-  <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
     {paginate(faculty, page).map(f => (
       <FacultyCard faculty={f} />
     ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,5 +4,5 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-white dark:bg-gray-800 shadow rounded p-4 transition-shadow hover:shadow-lg animate-fade;
+  @apply bg-gray-100 dark:bg-gray-800 shadow rounded p-4 transition-shadow hover:shadow-lg animate-fade;
 }


### PR DESCRIPTION
## Summary
- show entire faculty photos using `object-contain`
- give each faculty card a subtle background color
- display one card per row on small screens

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684af0cf5ecc832f9e4a84529bdc3960