### PR TITLE
Fix card height by clamping dept text

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -11,7 +11,7 @@ const { faculty } = Astro.props;
       class="w-full h-auto max-h-40 md:max-h-48 object-contain rounded mb-2"
     />
     <h3 class="text-lg font-semibold">{faculty.name}</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-300">{faculty.dept}</p>
+    <p class="text-sm text-gray-600 dark:text-gray-300 clamp-two-lines min-h-[3rem]">{faculty.dept}</p>
     <div class="space-y-1 mt-1">
       <div class="flex items-center gap-1">
         <span class="text-sm font-medium">Teaching:</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,3 +6,11 @@
 .card {
   @apply bg-gray-100 dark:bg-gray-800 shadow rounded p-4 transition-shadow hover:shadow-lg animate-fade;
 }
+
+/* Utility class to keep multiline text from growing cards */
+.clamp-two-lines {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}


### PR DESCRIPTION
## Summary
- ensure department text doesn't change card size with a clamp-two-lines CSS rule
- apply the clamp to each faculty card

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684af207ab60832fb7b7161b020f051f