### PR TITLE
Update faculty cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@astrojs/image": "^0.18.0",
     "@astrojs/react": "^4.3.0",
     "@astrojs/tailwind": "^6.0.2",
-    "@motionone/react": "^10.16.4",
     "@tailwindcss/postcss": "^4.1.10",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",

--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -8,22 +8,22 @@ const { faculty } = Astro.props;
       src={faculty.photo}
       alt={`Photo of ${faculty.name}`}
       loading="lazy"
-      class="w-full h-auto max-h-40 md:max-h-48 object-contain rounded mb-2"
+      class="w-full h-auto max-h-56 md:max-h-72 object-contain rounded mb-2"
     />
     <h3 class="text-lg font-semibold">{faculty.name}</h3>
-    <p class="text-sm text-gray-600 dark:text-gray-300 clamp-two-lines min-h-[3rem]">{faculty.dept}</p>
-    <div class="space-y-1 mt-1">
-      <div class="flex items-center gap-1">
-        <span class="text-sm font-medium">Teaching:</span>
-        <RatingWidget rating={faculty.teachingRating} showValue={true} client:load />
+    <p class="text-sm text-gray-600 dark:text-gray-300 truncate min-h-[3rem]">{faculty.dept}</p>
+    <div class="grid grid-cols-3 gap-2 mt-2 text-center">
+      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1">
+        <span class="text-xs font-medium">Teaching</span>
+        <RatingWidget rating={faculty.teachingRating} client:load />
       </div>
-      <div class="flex items-center gap-1">
-        <span class="text-sm font-medium">Attendance:</span>
-        <RatingWidget rating={faculty.attendanceRating} showValue={true} client:load />
+      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1">
+        <span class="text-xs font-medium">Attendance</span>
+        <RatingWidget rating={faculty.attendanceRating} client:load />
       </div>
-      <div class="flex items-center gap-1">
-        <span class="text-sm font-medium">Correction:</span>
-        <RatingWidget rating={faculty.correctionRating} showValue={true} client:load />
+      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1">
+        <span class="text-xs font-medium">Correction</span>
+        <RatingWidget rating={faculty.correctionRating} client:load />
       </div>
     </div>
     <p class="text-sm mt-1">{faculty.ratingsCount} rating{faculty.ratingsCount === 1 ? '' : 's'}</p>

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -1,25 +1,26 @@
-import { motion } from '@motionone/react';
 import type { FC } from 'react';
 
 interface Props {
   rating: number;
-  showValue?: boolean;
+  showValue?: boolean; // retained for compatibility but ignored
   disabled?: boolean;
 }
 
-const RatingWidget: FC<Props> = ({ rating, showValue = false }) => {
+const getColor = (rating: number) => {
+  if (rating > 4) return 'bg-green-600 text-white';
+  if (rating > 3.5) return 'bg-green-500 text-white';
+  if (rating >= 3) return 'bg-yellow-400 text-gray-900';
+  if (rating >= 2) return 'bg-red-500 text-white';
+  return 'bg-red-700 text-white';
+};
+
+const RatingWidget: FC<Props> = ({ rating }) => {
+  const classes = `px-2 py-1 rounded font-bold text-sm ${getColor(rating)}`;
   return (
-    <div
-      aria-label={`Average rating ${rating}`}
-      className="flex items-center gap-1 text-yellow-500 text-sm md:text-base"
-    >
-      {[1, 2, 3, 4, 5].map((i) => (
-        <motion.span key={i} initial={{ scale: 0 }} animate={{ scale: 1 }}>
-          {i <= Math.round(rating) ? '★' : '☆'}
-        </motion.span>
-      ))}
-      {showValue && <span className="ml-1">{rating.toFixed(1)}</span>}
+    <div aria-label={`Rating ${rating}`} className={classes}>
+      {rating.toFixed(1)}
     </div>
   );
 };
+
 export default RatingWidget;


### PR DESCRIPTION
## Summary
- enlarge faculty image display
- truncate specialization lines
- show color-coded rating numbers in boxes
- remove unused `@motionone/react` dependency

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684af3b57594832fa1dcd9662c848de4