### PR TITLE
Improve faculty card UI, pagination and add dark mode

### DIFF
--- a/public/darkMode.js
+++ b/public/darkMode.js
@@ -1,0 +1,16 @@
+(function(){
+  const root = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+    root.classList.add('dark');
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('dark-mode-toggle');
+    if (btn) {
+      btn.addEventListener('click', () => {
+        const isDark = root.classList.toggle('dark');
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+      });
+    }
+  });
+})();

--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -9,6 +9,7 @@ const { faculty } = Astro.props;
       src={faculty.photo}
       alt={`Photo of ${faculty.name}`}
       loading="lazy"
+      onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
       class="w-full h-auto max-h-56 md:max-h-72 object-contain rounded mb-2"
     />
     <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
@@ -25,7 +26,7 @@ const { faculty } = Astro.props;
         <RatingWidget rating={faculty.correctionRating} client:load />
       </div>
     </div>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;">{faculty.dept}</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center clamp-three-lines">{faculty.dept}</p>
     <p class="text-sm mt-1">{faculty.ratingsCount} rating{faculty.ratingsCount === 1 ? '' : 's'}</p>
   </article>
 </a>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -12,10 +12,14 @@ const { title = 'Faculty Ranker' } = Astro.props;
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+2" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+3" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+4" />
-  <script type="module" src="/viewTransitions.js" />
+  <script type="module" src="/viewTransitions.js"></script>
+  <script type="module" src="/darkMode.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-gray-900 dark:to-gray-800 text-gray-900 dark:text-gray-100">
-  <header class="p-4 text-center text-2xl font-bold">Faculty Ranker</header>
+  <header class="relative p-4 flex justify-center items-center">
+    <h1 class="text-2xl font-bold">Faculty Ranker</h1>
+    <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded bg-gray-200 dark:bg-gray-700">🌓</button>
+  </header>
   <main class="container mx-auto p-4"><slot /></main>
 </body>
 </html>

--- a/src/pages/faculty/[id].astro
+++ b/src/pages/faculty/[id].astro
@@ -12,7 +12,12 @@ if (!person) throw Astro.redirect('/', 302);
 <Base title={`${person.name} - Faculty Ranker`}>
   <div class="flex flex-col items-center">
     <h1 class="text-2xl font-bold mb-2 text-center">{person.name}</h1>
-    <img src={person.photo} alt={`Photo of ${person.name}`} class="w-64 h-auto rounded mb-4" />
+    <img
+      src={person.photo}
+      alt={`Photo of ${person.name}`}
+      onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
+      class="w-64 h-auto rounded mb-4"
+    />
     <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
       <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1">
         <span class="text-xs font-medium">Teaching</span>
@@ -27,7 +32,7 @@ if (!person) throw Astro.redirect('/', 302);
         <RatingWidget rating={person.correctionRating} client:load />
       </div>
     </div>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center" style="display:-webkit-box;-webkit-line-clamp:3;-webkit-box-orient:vertical;overflow:hidden;">{person.dept}</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center clamp-three-lines">{person.dept}</p>
     <p class="mt-1 mb-2 text-sm">{person.ratingsCount} rating{person.ratingsCount === 1 ? '' : 's'}</p>
     <p class="mt-4">This is a placeholder bio for {person.name}. Rating data will be available soon.</p>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,6 +15,6 @@ let filteredIds = faculty.map(f => f.id);
     ))}
   </div>
   <nav class="mt-4 flex justify-center gap-2">
-    <a href="/page/2" class="underline">Next</a>
+    <a href="/page/2" class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">Next &rarr;</a>
   </nav>
 </Base>

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -21,7 +21,11 @@ if (page < 1 || page > pages) {
     ))}
   </div>
   <nav class="mt-4 flex justify-center gap-2">
-    {page > 1 && <a href={`/page/${page-1}`} class="underline">Prev</a>}
-    {page < pages && <a href={`/page/${page+1}`} class="underline">Next</a>}
+    {page > 1 && (
+      <a href={`/page/${page-1}`} class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">&larr; Prev</a>
+    )}
+    {page < pages && (
+      <a href={`/page/${page+1}`} class="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700">Next &rarr;</a>
+    )}
   </nav>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,3 +14,12 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 }
+
+/* Ensure faculty cards stay uniform height even with shorter text */
+.clamp-three-lines {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  min-height: 3.75rem;
+}


### PR DESCRIPTION
## Summary
- keep card heights consistent even with short specialization text
- add fallback placeholder images when photos are missing
- improve pagination button styling
- add a dark mode toggle to the header

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684afc8f5300832f8d2d4f50d99aae3b