### PR TITLE
Fix rating message capitalization

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -27,6 +27,6 @@ const { faculty } = Astro.props;
       </div>
     </div>
     <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center clamp-three-lines">{faculty.dept}</p>
-    <p class="text-sm mt-1 self-start text-gray-500 dark:text-gray-400">rated by {faculty.ratingsCount} student{faculty.ratingsCount === 1 ? '' : 's'}</p>
+    <p class="text-sm mt-1 self-start text-gray-500 dark:text-gray-400">Rated by {faculty.ratingsCount} student{faculty.ratingsCount === 1 ? '' : 's'}</p>
   </article>
 </a>


### PR DESCRIPTION
## Summary
- update faculty card 'rated by' text to start with a capital letter

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b069dc25c832fb0562bed9e563bf2