### PR TITLE
Fix search bar position

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -18,9 +18,12 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-black dark:to-gray-900 text-gray-900 dark:text-gray-100">
  
-  <header class="relative p-4 mt-4 mb-2 flex justify-center items-center">
-    <h1 class="text-2xl font-bold">{headerTitle}</h1>
-    <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded bg-gray-200 dark:bg-gray-700">🌓</button>
+  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
+    <div class="w-full flex justify-center items-center">
+      <h1 class="text-2xl font-bold">{headerTitle}</h1>
+      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded bg-gray-200 dark:bg-gray-700">🌓</button>
+    </div>
+    <slot name="search" />
   </header>
   <main class="container mx-auto p-4"><slot /></main>
 </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const page = 1;
 let filteredIds = faculty.map(f => f.id);
 ---
 <Base>
-  <div class="mb-4" id="search"><SearchBar data={faculty} onFilter={(ids)=>filteredIds = ids} client:load /></div>
+  <div slot="search" class="w-full"><SearchBar data={faculty} onFilter={(ids)=>filteredIds = ids} client:load /></div>
   <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
     {paginate(faculty.filter(f=>filteredIds.includes(f.id)), page).map(f => (
       <FacultyCard faculty={f} />


### PR DESCRIPTION
## Summary
- add named slot in `Base.astro` header for search bar
- render `SearchBar` inside the new slot on the index page

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b100ba0a0832fb0f4ba83ef677e88