### PR TITLE
Prevent page scroll while adjusting rating

### DIFF
--- a/public/ratingSlider.js
+++ b/public/ratingSlider.js
@@ -47,9 +47,15 @@
     const stop=()=>{
       bubble.classList.add('hidden');
       document.body.classList.remove('no-scroll');
+      document.documentElement.classList.remove('no-scroll');
     };
     slider.addEventListener('input',update);
-    slider.addEventListener('pointerdown',()=>{bubble.classList.remove('hidden');document.body.classList.add('no-scroll');update();});
+    slider.addEventListener('pointerdown',()=>{
+      bubble.classList.remove('hidden');
+      document.body.classList.add('no-scroll');
+      document.documentElement.classList.add('no-scroll');
+      update();
+    });
     slider.addEventListener('pointerup',stop);
     slider.addEventListener('pointercancel',stop);
     slider.addEventListener('change',stop);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -60,6 +60,8 @@
   font-size: 0.875rem;
 }
 
-.no-scroll {
+html.no-scroll,
+body.no-scroll {
   overflow: hidden;
+  touch-action: none;
 }


### PR DESCRIPTION
## Summary
- stop document scrolling when rating sliders are being dragged
- ensure CSS disables scroll on the html element as well

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b10538e84832faea2472c5062f37b