### PR TITLE
Keep faculty images same height

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -10,7 +10,7 @@ const { faculty } = Astro.props;
     alt={`Photo of ${faculty.name}`}
     loading="lazy"
     onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
-    class="w-full h-auto max-h-56 md:max-h-72 object-contain rounded-lg shadow mb-2"
+    class="h-64 w-auto rounded-xl shadow-lg mb-2"
   />
     <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
       <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">

--- a/src/pages/faculty/[id].astro
+++ b/src/pages/faculty/[id].astro
@@ -15,7 +15,7 @@ if (!person) throw Astro.redirect('/', 302);
       src={person.photo}
       alt={`Photo of ${person.name}`}
       onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
-      class="w-64 h-auto rounded-lg shadow mb-4 md:mb-0"
+      class="h-64 w-auto rounded-xl shadow-lg mb-4 md:mb-0"
     />
     <div class="flex flex-col items-center md:items-start">
       <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">


### PR DESCRIPTION
## Summary
- set faculty card images to a fixed height so all pictures match
- update individual faculty page image style to the same classes

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bb399aae8832fa6095fb958e07ee8