### PR TITLE
Improve UI and live search

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -11,24 +11,24 @@ const { faculty } = Astro.props;
     loading="lazy"
     onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
 
-    class="h-64 w-auto rounded-xl shadow-lg mb-2"
+    class="h-64 w-auto faculty-photo mb-2"
 
   />
     <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
         <RatingWidget rating={faculty.teachingRating} client:load />
         <span class="text-xs font-medium">Teaching</span>
       </div>
-      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
         <RatingWidget rating={faculty.attendanceRating} client:load />
         <span class="text-xs font-medium">Attendance</span>
       </div>
-      <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
         <RatingWidget rating={faculty.correctionRating} client:load />
         <span class="text-xs font-medium">Correction</span>
       </div>
     </div>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center clamp-three-lines">{faculty.dept}</p>
+    <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center clamp-two-lines">{faculty.dept}</p>
     <p class="text-sm mt-1 self-start text-gray-500 dark:text-gray-400">Rated by {faculty.ratingsCount} student{faculty.ratingsCount === 1 ? '' : 's'}</p>
   </article>
 </a>

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -16,7 +16,7 @@ const getColor = (rating: number) => {
 };
 
 const RatingWidget: FC<Props> = ({ rating }) => {
-  const classes = `px-2 py-1 rounded font-bold text-sm ${getColor(rating)}`;
+  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getColor(rating)}`;
   return (
     <div aria-label={`Rating ${rating}`} className={classes}>
       {rating.toFixed(1)}

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -1,7 +1,45 @@
 ---
+import faculty from '../data/faculty.json';
 const { query = '', placeholder = 'Search by name...' } = Astro.props;
+const names = faculty.map(f => ({ name: f.name, id: f.id }));
 ---
-<form action="/" method="get" class="flex w-full gap-2">
-  <input type="search" name="q" value={query} aria-label="Search faculty" class="flex-1 p-2 border rounded" placeholder={placeholder} />
-  <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded shadow">Search</button>
+<form id="search-form" action="/" method="get" class="relative flex w-full gap-2">
+  <input id="search-input" type="search" name="q" value={query} aria-label="Search faculty" class="flex-1 p-2 border rounded-lg" placeholder={placeholder} autocomplete="off" />
+  <button type="submit" class="px-4 py-2 bg-gray-600 text-white rounded-lg shadow dark:bg-black">Search</button>
+  <ul id="suggestions" class="hidden absolute left-0 top-full mt-1 w-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-800 rounded-lg shadow-lg max-h-60 overflow-auto z-10"></ul>
 </form>
+<script type="module">
+  const list = {JSON.stringify(names)};
+  const input = document.getElementById('search-input');
+  const suggestions = document.getElementById('suggestions');
+  const form = document.getElementById('search-form');
+  function update(){
+    const q = input.value.trim().toLowerCase();
+    suggestions.innerHTML = '';
+    if(!q){
+      suggestions.classList.add('hidden');
+      return;
+    }
+    const matches = list.filter(i => i.name.toLowerCase().includes(q)).slice(0,10);
+    if(matches.length === 0){
+      suggestions.classList.add('hidden');
+      return;
+    }
+    for(const m of matches){
+      const li = document.createElement('li');
+      li.className = 'px-3 py-1 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg';
+      const a = document.createElement('a');
+      a.href = `/faculty/${m.id}`;
+      a.textContent = m.name;
+      li.appendChild(a);
+      suggestions.appendChild(li);
+    }
+    suggestions.classList.remove('hidden');
+  }
+  input.addEventListener('input', update);
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const first = suggestions.querySelector('a');
+    if(first) window.location.href = first.href;
+  });
+</script>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -21,7 +21,7 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
     <div class="w-full flex justify-center items-center">
       <h1 class="text-2xl font-bold">{headerTitle}</h1>
-      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded bg-gray-200 dark:bg-gray-700">🌓</button>
+      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-gray-700">🌓</button>
     </div>
     <slot name="search" />
   </header>

--- a/src/pages/faculty/[id].astro
+++ b/src/pages/faculty/[id].astro
@@ -16,25 +16,25 @@ if (!person) throw Astro.redirect('/', 302);
       alt={`Photo of ${person.name}`}
       onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
 
-      class="h-64 w-auto rounded-xl shadow-lg mb-4 md:mb-0"
+      class="h-64 w-auto faculty-photo mb-4 md:mb-0"
 
     />
     <div class="flex flex-col items-center md:items-start">
       <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-        <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
           <RatingWidget rating={person.teachingRating} client:load />
           <span class="text-xs font-medium">Teaching</span>
         </div>
-        <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
           <RatingWidget rating={person.attendanceRating} client:load />
           <span class="text-xs font-medium">Attendance</span>
         </div>
-        <div class="p-2 rounded bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
           <RatingWidget rating={person.correctionRating} client:load />
           <span class="text-xs font-medium">Correction</span>
         </div>
       </div>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center md:text-left clamp-three-lines">{person.dept}</p>
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-2 text-center md:text-left clamp-two-lines">{person.dept}</p>
       <p class="mt-1 mb-2 text-sm text-gray-500 dark:text-gray-400 self-start">Rated by {person.ratingsCount} student{person.ratingsCount === 1 ? '' : 's'}</p>
  
       <form class="mt-4 flex flex-col items-center gap-4 w-full" onsubmit="event.preventDefault(); alert('Thanks for rating!');">
@@ -53,7 +53,7 @@ if (!person) throw Astro.redirect('/', 302);
           <input id="corr" type="range" min="1" max="5" step="0.1" class="rating-slider w-48" />
           <span class="rating-value text-sm w-8 text-right"></span>
         </div>
-        <button type="submit" class="mt-2 px-4 py-1 rounded bg-black text-white hover:bg-gray-800 self-start">Submit Rating</button>
+        <button type="submit" class="mt-2 px-4 py-1 rounded-lg bg-black text-white hover:bg-gray-800 self-start">Submit Rating</button>
       </form>
     </div>
   </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,6 +17,6 @@ const list = query ? faculty.filter(f => f.name.toLowerCase().includes(query.toL
     ))}
   </div>
   <nav class="mt-4 flex justify-center gap-2">
-    <a href="/page/2" class="px-4 py-2 rounded bg-black text-white hover:bg-gray-800">Next &rarr;</a>
+    <a href="/page/2" class="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800">Next &rarr;</a>
   </nav>
 </Base>

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -22,10 +22,10 @@ if (page < 1 || page > pages) {
   </div>
   <nav class="mt-4 flex justify-center gap-2">
     {page > 1 && (
-      <a href={`/page/${page-1}`} class="px-4 py-2 rounded bg-black text-white hover:bg-gray-800">&larr; Prev</a>
+      <a href={`/page/${page-1}`} class="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800">&larr; Prev</a>
     )}
     {page < pages && (
-      <a href={`/page/${page+1}`} class="px-4 py-2 rounded bg-black text-white hover:bg-gray-800">Next &rarr;</a>
+      <a href={`/page/${page+1}`} class="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800">Next &rarr;</a>
     )}
   </nav>
 </Base>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-100 dark:bg-gray-800 p-4 transition-shadow animate-fade;
+  @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-lg transition-shadow animate-fade;
 }
 
 /* Utility class to keep multiline text from growing cards */
@@ -58,6 +58,16 @@
   min-width: 2rem;
   text-align: right;
   font-size: 0.875rem;
+}
+
+/* Consistent photo shadow */
+.faculty-photo {
+  @apply rounded-lg shadow-lg;
+  box-shadow: 0 10px 15px rgba(0,0,0,0.3);
+}
+
+.dark .faculty-photo {
+  box-shadow: 0 10px 15px rgba(255,255,255,0.2);
 }
 
 html.no-scroll,


### PR DESCRIPTION
## Summary
- unify border radius for UI blocks
- enhance image shadows and add dark mode variant
- revamp search bar with grey/black button and live suggestions
- clamp specialization text to two lines

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bbbc94100832fbf5a18d4ba5b08ba