### PR TITLE
Improve search with fuzzy matching

### DIFF
--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -1,5 +1,7 @@
 ---
 import faculty from '../data/faculty.json';
+import MiniSearch from 'minisearch';
+
 const { query = '', placeholder = 'Search by name...' } = Astro.props;
 const names = faculty.map(f => ({ name: f.name, id: f.id }));
 ---
@@ -10,17 +12,25 @@ const names = faculty.map(f => ({ name: f.name, id: f.id }));
 </form>
 <script type="module">
   const list = {JSON.stringify(names)};
+  const miniSearch = new MiniSearch({
+    fields: ['name'],
+    storeFields: ['name', 'id']
+  });
+  miniSearch.addAll(list);
+
   const input = document.getElementById('search-input');
   const suggestions = document.getElementById('suggestions');
   const form = document.getElementById('search-form');
+
   function update(){
-    const q = input.value.trim().toLowerCase();
+    const q = input.value.trim();
     suggestions.innerHTML = '';
     if(!q){
       suggestions.classList.add('hidden');
       return;
     }
-    const matches = list.filter(i => i.name.toLowerCase().includes(q)).slice(0,10);
+    const results = miniSearch.search(q, { prefix: true, fuzzy: 0.2 }).slice(0,10);
+    const matches = results.map(r => ({ name: r.name, id: r.id }));
     if(matches.length === 0){
       suggestions.classList.add('hidden');
       return;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,10 +3,22 @@ import Base from '../layouts/Base.astro';
 import faculty from '../data/faculty.json';
 import FacultyCard from '../components/FacultyCard.astro';
 import { paginate, PER_PAGE } from '../utils/pagination';
+import MiniSearch from 'minisearch';
 const page = 1;
 const url = new URL(Astro.request.url);
 const query = url.searchParams.get('q') ?? '';
-const list = query ? faculty.filter(f => f.name.toLowerCase().includes(query.toLowerCase())) : faculty;
+
+let list = faculty;
+if (query) {
+  const miniSearch = new MiniSearch({
+    fields: ['name'],
+    storeFields: ['id']
+  });
+  miniSearch.addAll(faculty.map(f => ({ id: f.id, name: f.name })));
+  const results = miniSearch.search(query, { prefix: true, fuzzy: 0.2 });
+  const map = new Map(faculty.map(f => [f.id, f]));
+  list = results.map(r => map.get(r.id)).filter(Boolean);
+}
 ---
 <Base>
   <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- use MiniSearch for fuzzy suggestions in `SearchBar`
- apply the same fuzzy search on the homepage results

## Testing
- `npx astro build` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_684bc60e3eac832fbeda9283b4d69133