### PR TITLE
Handle missing ratings

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -4,10 +4,10 @@ const { faculty } = Astro.props;
 ---
 <a href={`/faculty/${faculty.id}`} class="block">
   <article class="card flex flex-col items-center" view-transition-name={`card-${faculty.id}`}>
-  <h3 class="text-lg font-bold text-center mb-2">{faculty.name}</h3>
+  <h3 class="text-lg font-bold text-center mb-2">{faculty.name || 'Unknown'}</h3>
   <img
     src={faculty.photo_url}
-    alt={`Photo of ${faculty.name}`}
+    alt={`Photo of ${faculty.name || 'Unknown'}`}
     loading="lazy"
     onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
 

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react';
 
 interface Props {
-  rating: number;
+  rating: number | null | undefined;
   showValue?: boolean; // retained for compatibility but ignored
   disabled?: boolean;
 }
@@ -16,10 +16,11 @@ const getColor = (rating: number) => {
 };
 
 const RatingWidget: FC<Props> = ({ rating }) => {
-  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getColor(rating)}`;
+  const value = typeof rating === 'number' ? rating : 0;
+  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getColor(value)}`;
   return (
-    <div aria-label={`Rating ${rating}`} className={classes}>
-      {rating.toFixed(1)}
+    <div aria-label={`Rating ${value}`} className={classes}>
+      {value.toFixed(1)}
     </div>
   );
 };

--- a/src/components/SearchBar.astro
+++ b/src/components/SearchBar.astro
@@ -4,7 +4,9 @@ import { fetchLists } from '../utils/supabase';
 
 const { query = '', placeholder = 'Search by name...' } = Astro.props;
 const faculty = await fetchLists();
-const names = faculty.map(f => ({ name: f.name, id: f.id }));
+const names = faculty
+  .filter(f => f.name && String(f.name).trim())
+  .map(f => ({ name: f.name, id: f.id }));
 ---
 <form id="search-form" action="/" method="get" class="relative flex w-full gap-2">
   <input id="search-input" type="search" name="q" value={query} aria-label="Search faculty" class="flex-1 p-2 border rounded-lg" placeholder={placeholder} autocomplete="off" />

--- a/src/utils/supabase.ts
+++ b/src/utils/supabase.ts
@@ -1,17 +1,19 @@
 import { createClient } from '@supabase/supabase-js';
 
 const supabaseUrl = 'https://dwyojdeyfaozeeplpbyr.supabase.co';
-const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR3eW9qZGV5ZmFvemVlcGxwYnlyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk3OTY5MTMsImV4cCI6MjA2NTM3MjkxM30.A3EWWal-iREIyXX6j2F5Dzdi9KBTJQXAF1GHVcpDHY8';
+const supabaseAnonKey =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR3eW9qZGV5ZmFvemVlcGxwYnlyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDk3OTY5MTMsImV4cCI6MjA2NTM3MjkxM30.A3EWWal-iREIyXX6j2F5Dzdi9KBTJQXAF1GHVcpDHY8';
 
 const supabase = createClient(supabaseUrl, supabaseAnonKey);
 
 export async function fetchLists() {
   try {
-    const { data, error } = await supabase
-      .from('lists')
-      .select('*');
+    const { data, error } = await supabase.from('lists').select('*');
     if (error) throw error;
-    return data ?? [];
+    const list = data ?? [];
+    const withName = list.filter((f: any) => f.name && String(f.name).trim());
+    const withoutName = list.filter((f: any) => !f.name || !String(f.name).trim());
+    return [...withName, ...withoutName];
   } catch (err) {
     console.error('Error fetching lists:', err);
     return [];


### PR DESCRIPTION
## Summary
- avoid `toFixed` on null ratings by defaulting to 0
- sort faculty with missing names to the end of the list
- ignore nameless faculty in search suggestions
- display "Unknown" when a faculty name is missing

## Testing
- `npm install`
- `npm run build` *(fails to fetch Supabase data)*

------
https://chatgpt.com/codex/tasks/task_e_684beaa38ff8832f8e2361000a6ca376