### PR TITLE
Enhance faculty cards

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -5,15 +5,15 @@ const { faculty } = Astro.props;
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
   <article class="card flex flex-col items-center" view-transition-name={`card-${faculty.id}`}>
   <h3 class="text-lg font-bold text-center mb-2">{faculty.name || 'Unknown'}</h3>
-  <img
-    src={faculty.photo_url}
-    alt={`Photo of ${faculty.name || 'Unknown'}`}
-    loading="lazy"
-    onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
-
-    class="h-64 w-auto faculty-photo mb-2"
-
-  />
+  <div class="photo-wrapper mb-2">
+    <img
+      src={faculty.photo_url}
+      alt={`Photo of ${faculty.name || 'Unknown'}`}
+      loading="lazy"
+      onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
+      class="faculty-photo"
+    />
+  </div>
     <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
       <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
         <RatingWidget rating={faculty.teaching_rating} client:load />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,11 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-lg transition-shadow animate-fade;
+  @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-lg transition-shadow transition-transform transform animate-fade;
+}
+
+.card:hover {
+  @apply shadow-xl scale-105 -translate-y-1;
 }
 
 /* Utility class to keep multiline text from growing cards */
@@ -62,12 +66,11 @@
 
 /* Consistent photo shadow */
 .faculty-photo {
-  @apply rounded-lg shadow-lg;
-  box-shadow: 0 10px 15px rgba(0,0,0,0.3);
+  @apply w-full h-full object-contain;
 }
 
-.dark .faculty-photo {
-  box-shadow: 0 10px 15px rgba(255,255,255,0.2);
+.photo-wrapper {
+  @apply w-full h-64 border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900;
 }
 
 html.no-scroll,


### PR DESCRIPTION
## Summary
- wrap faculty photos in a rounded bordered container
- animate cards on hover for a subtle lift
- ensure images scale uniformly within the new container

## Testing
- `npm install`
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c02dd4164832f8c35fc8bd482d0a7