### PR TITLE
Fix faculty card layout

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -15,7 +15,7 @@ const { faculty } = Astro.props;
     </div>
     <div class="flex flex-col items-start flex-1">
       <h3 class="text-lg font-bold mb-2">{faculty.name || 'Unknown'}</h3>
-      <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
+      <div class="flex flex-col gap-2 mb-2 w-full text-center">
         <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
           <RatingWidget rating={faculty.teaching_rating} client:load />
           <span class="text-xs font-medium">Teaching</span>


### PR DESCRIPTION
## Summary
- stack rating widgets vertically in faculty cards

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c0841700c832fb6afee48ced26ad7