### PR TITLE
Add rating bars for faculty

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -1,5 +1,5 @@
 ---
-import RatingWidget from './RatingWidget.tsx';
+import RatingBar from './RatingBar.tsx';
 const { faculty } = Astro.props;
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
@@ -15,19 +15,10 @@ const { faculty } = Astro.props;
     </div>
     <div class="flex flex-col items-start flex-1">
       <h3 class="text-lg font-bold mb-2">{faculty.name || 'Unknown'}</h3>
-      <div class="flex flex-col gap-2 mb-2 w-full text-center">
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={faculty.teaching_rating} client:load />
-          <span class="text-xs font-medium">Teaching</span>
-        </div>
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={faculty.attendance_rating} client:load />
-          <span class="text-xs font-medium">Attendance</span>
-        </div>
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={faculty.correction_rating} client:load />
-          <span class="text-xs font-medium">Correction</span>
-        </div>
+      <div class="flex flex-col gap-2 mb-2 w-full">
+        <RatingBar rating={faculty.teaching_rating} label="Teaching" client:load />
+        <RatingBar rating={faculty.attendance_rating} label="Attendance" client:load />
+        <RatingBar rating={faculty.correction_rating} label="Correction" client:load />
       </div>
       <p class="text-sm mt-1 text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
     </div>

--- a/src/components/RatingBar.tsx
+++ b/src/components/RatingBar.tsx
@@ -1,0 +1,41 @@
+import type { FC } from 'react';
+
+interface Props {
+  rating: number | null | undefined;
+  label: string;
+}
+
+const getColor = (rating: number) => {
+  if (rating === 5) return { bg: 'bg-violet-600', text: 'text-violet-600' };
+  if (rating > 4) return { bg: 'bg-green-600', text: 'text-green-600' };
+  if (rating > 3.5) return { bg: 'bg-green-500', text: 'text-green-500' };
+  if (rating >= 3) return { bg: 'bg-yellow-400', text: 'text-yellow-400' };
+  if (rating >= 2) return { bg: 'bg-red-500', text: 'text-red-500' };
+  return { bg: 'bg-red-700', text: 'text-red-700' };
+};
+
+const icons: Record<string, string> = {
+  Teaching: '📚',
+  Attendance: '📅',
+  Correction: '📝',
+};
+
+const RatingBar: FC<Props> = ({ rating, label }) => {
+  const value = typeof rating === 'number' ? rating : 0;
+  const { bg, text } = getColor(value);
+  const width = `${Math.min(Math.max(value, 0), 5) / 5 * 100}%`;
+  const icon = icons[label] || '';
+  return (
+    <div className="w-full my-1">
+      <div className="flex justify-between items-baseline px-1">
+        <span className={`flex items-center gap-1 text-xs font-semibold ${text}`}>{icon}{label}</span>
+        <span className={`text-xs font-semibold ${text}`}>{value.toFixed(1)}</span>
+      </div>
+      <div className="w-full h-3 rounded bg-gray-300 dark:bg-gray-700 overflow-hidden shadow">
+        <div className={`${bg} h-full`} style={{ width }}></div>
+      </div>
+    </div>
+  );
+};
+
+export default RatingBar;

--- a/src/pages/faculty/[id].astro
+++ b/src/pages/faculty/[id].astro
@@ -1,6 +1,6 @@
 ---
 import Base from '../../layouts/Base.astro';
-import RatingWidget from '../../components/RatingWidget.tsx';
+import RatingBar from '../../components/RatingBar.tsx';
 import { fetchLists } from '../../utils/supabase';
 export async function getStaticPaths() {
   const faculty = await fetchLists();
@@ -22,19 +22,10 @@ if (!person) throw Astro.redirect('/', 302);
 
     />
     <div class="flex flex-col items-center md:items-start">
-      <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={person.teaching_rating} client:load />
-          <span class="text-xs font-medium">Teaching</span>
-        </div>
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={person.attendance_rating} client:load />
-          <span class="text-xs font-medium">Attendance</span>
-        </div>
-        <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-          <RatingWidget rating={person.correction_rating} client:load />
-          <span class="text-xs font-medium">Correction</span>
-        </div>
+      <div class="flex flex-col gap-2 mb-2 w-full">
+        <RatingBar rating={person.teaching_rating} label="Teaching" client:load />
+        <RatingBar rating={person.attendance_rating} label="Attendance" client:load />
+        <RatingBar rating={person.correction_rating} label="Correction" client:load />
       </div>
       <p class="mt-1 mb-2 text-sm text-gray-500 dark:text-gray-400 self-start">Rated by {person.total_ratings} student{person.total_ratings === 1 ? '' : 's'}</p>
  

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-lg transition-shadow transition-transform transform animate-fade;
+  @apply bg-gray-100 dark:bg-gray-800 p-4 rounded-lg border border-gray-300 dark:border-gray-700 transition-shadow transition-transform transform animate-fade;
 }
 
 .card:hover {
@@ -72,7 +72,8 @@
 
 .photo-wrapper {
 
-  @apply w-48 h-64 border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900;
+  /* Smaller size with maintained 3:4 ratio, thicker border, slight left shift and shadow */
+  @apply w-24 h-32 border-4 border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow -ml-4;
 
 }
 


### PR DESCRIPTION
## Summary
- replace rating widgets with progress bars
- show rating labels and values with matching colors
- shrink faculty photo, shift left and add shadow
- increase bar thickness and add icons for each rating
- add borders to faculty cards

## Testing
- `npm install`
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c09b5cd30832fb24670594265568a