### PR TITLE
Adjust FacultyCard UI

### DIFF
--- a/src/components/RatingBar.tsx
+++ b/src/components/RatingBar.tsx
@@ -74,9 +74,9 @@ const RatingBar: FC<Props> = ({ rating, label }) => {
     <div className="w-full my-1">
       <div className="flex justify-between items-baseline px-1">
         <span className={`flex items-center gap-1 text-sm font-semibold ${text}`}>{icon}{label}</span>
-        <span className={`text-base font-semibold ${text}`}>{value.toFixed(1)}</span>
+        <span className={`text-base font-bold ${text}`}>{value.toFixed(1)}</span>
       </div>
-      <div className="w-11/12 mx-auto h-3 rounded bg-gray-300 dark:bg-gray-700 overflow-hidden shadow-lg">
+      <div className="w-11/12 mx-auto h-2 rounded bg-gray-300 dark:bg-gray-700 overflow-hidden shadow-lg">
         <div className={`${bg} h-full shadow-inner brightness-110`} style={{ width }}></div>
       </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-100 dark:bg-white p-4 rounded-lg border-2 border-black dark:border-white transition-shadow transition-transform transform animate-fade;
+  @apply bg-gray-50 dark:bg-gray-100 p-4 rounded-lg border-2 border-black dark:border-black shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
 .card:hover {
@@ -72,8 +72,8 @@
 
 .photo-wrapper {
 
-  /* Smaller size with maintained 3:4 ratio, thicker border, slight left shift and shadow */
-  @apply w-24 h-32 border-4 border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow -ml-4;
+  /* Increased size with maintained 3:4 ratio, dark border and stronger shadow */
+  @apply w-28 h-36 border-4 border-gray-800 dark:border-gray-800 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg -ml-4;
 
 
 }


### PR DESCRIPTION
## Summary
- tweak card backgrounds and add base shadow
- enlarge faculty photo with darker border
- slim down rating bars and bold the numbers

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c156df570832f8c1860f9e6cc41fe