### PR TITLE
Align faculty card image

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -3,24 +3,26 @@ import RatingBar from './RatingBar.tsx';
 const { faculty } = Astro.props;
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
-  <article class="card flex items-center gap-4" view-transition-name={`card-${faculty.id}`}>
-    <div class="photo-wrapper">
-      <img
-        src={faculty.photo_url}
-        alt={`Photo of ${faculty.name || 'Unknown'}`}
-        loading="lazy"
-        onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
-        class="faculty-photo"
-      />
-    </div>
-    <div class="flex flex-col items-start flex-1">
-      <h3 class="text-lg font-bold mb-2">{faculty.name || 'Unknown'}</h3>
-      <div class="flex flex-col gap-2 mb-2 w-full">
-        <RatingBar rating={faculty.teaching_rating} label="Teaching" client:load />
-        <RatingBar rating={faculty.attendance_rating} label="Attendance" client:load />
-        <RatingBar rating={faculty.correction_rating} label="Correction" client:load />
+  <article class="card" view-transition-name={`card-${faculty.id}`}>
+    <h3 class="text-lg font-bold text-center mb-2 w-full">{faculty.name || 'Unknown'}</h3>
+    <div class="flex items-start gap-4">
+      <div class="photo-wrapper mt-2">
+        <img
+          src={faculty.photo_url}
+          alt={`Photo of ${faculty.name || 'Unknown'}`}
+          loading="lazy"
+          onerror="this.src='https://placehold.co/300x400?text=No+Photo';this.onerror=null;"
+          class="faculty-photo"
+        />
       </div>
-      <p class="text-sm mt-1 text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
+      <div class="flex flex-col items-start flex-1">
+        <div class="flex flex-col gap-2 mb-2 w-full">
+          <RatingBar rating={faculty.teaching_rating} label="Teaching" client:load />
+          <RatingBar rating={faculty.attendance_rating} label="Attendance" client:load />
+          <RatingBar rating={faculty.correction_rating} label="Correction" client:load />
+        </div>
+        <p class="text-sm mt-1 text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
+      </div>
     </div>
   </article>
 </a>

--- a/src/components/RatingBar.tsx
+++ b/src/components/RatingBar.tsx
@@ -71,12 +71,12 @@ const RatingBar: FC<Props> = ({ rating, label }) => {
   const width = `${Math.min(Math.max(value, 0), 5) / 5 * 100}%`;
   const icon = icons[label] || null;
   return (
-    <div className="w-full my-1">
+    <div className="w-full my-1 drop-shadow-lg">
       <div className="flex justify-between items-baseline px-1">
-        <span className={`flex items-center gap-1 text-sm font-semibold ${text}`}>{icon}{label}</span>
-        <span className={`text-base font-bold ${text}`}>{value.toFixed(1)}</span>
+        <span className={`flex items-center gap-1 text-sm font-semibold drop-shadow-md ${text}`}>{icon}{label}</span>
+        <span className={`text-base font-bold drop-shadow-md ${text}`}>{value.toFixed(1)}</span>
       </div>
-      <div className="w-11/12 mx-auto h-2 rounded bg-gray-300 dark:bg-gray-700 overflow-hidden shadow-lg">
+      <div className="w-11/12 mx-auto h-2 rounded bg-gray-300 dark:bg-gray-700 overflow-hidden shadow-2xl drop-shadow-xl">
         <div className={`${bg} h-full shadow-inner brightness-110`} style={{ width }}></div>
       </div>
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-50 dark:bg-gray-100 p-4 rounded-lg border-2 border-black dark:border-black shadow-md transition-shadow transition-transform transform animate-fade;
+  @apply bg-gray-50 dark:bg-gray-100 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
 .card:hover {
@@ -72,8 +72,8 @@
 
 .photo-wrapper {
 
-  /* Increased size with maintained 3:4 ratio, dark border and stronger shadow */
-  @apply w-28 h-36 border-4 border-gray-800 dark:border-gray-800 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg -ml-4;
+  /* Increased size with maintained 3:4 ratio and stronger shadow */
+  @apply w-28 h-36 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg -ml-4;
 
 
 }


### PR DESCRIPTION
## Summary
- move faculty name to the top and center
- offset the photo wrapper so the image aligns with the ratings
- add strong shadows on rating bars and metrics

## Testing
- `npm run build` *(fails: fetchLists TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c16626ae8832f82fc9482f1359799