### PR TITLE
Adjust faculty card layout

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -4,8 +4,7 @@ const { faculty } = Astro.props;
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
   <article class="card" view-transition-name={`card-${faculty.id}`}>
-    <h3 class="text-lg font-bold text-center mb-2 w-full">{faculty.name || 'Unknown'}</h3>
-    <div class="flex items-start gap-4">
+    <div class="flex items-center gap-4 mb-2">
       <div class="photo-wrapper mt-2">
         <img
           src={faculty.photo_url}
@@ -15,24 +14,22 @@ const { faculty } = Astro.props;
           class="faculty-photo"
         />
       </div>
-      <div class="flex flex-col items-start flex-1">
- 
-        <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-          <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={faculty.teaching_rating} client:load />
-            <span class="text-xs font-medium">Teaching</span>
-          </div>
-          <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={faculty.attendance_rating} client:load />
-            <span class="text-xs font-medium">Attendance</span>
-          </div>
-          <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={faculty.correction_rating} client:load />
-            <span class="text-xs font-medium">Correction</span>
-          </div>
-        </div>
-        <p class="text-sm mt-1 text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
+      <h3 class="text-lg font-bold">{faculty.name || 'Unknown'}</h3>
+    </div>
+    <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <RatingWidget rating={faculty.teaching_rating} client:load />
+        <span class="text-xs font-medium">Teaching</span>
+      </div>
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <RatingWidget rating={faculty.attendance_rating} client:load />
+        <span class="text-xs font-medium">Attendance</span>
+      </div>
+      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+        <RatingWidget rating={faculty.correction_rating} client:load />
+        <span class="text-xs font-medium">Correction</span>
       </div>
     </div>
+    <p class="text-sm text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
   </article>
 </a>


### PR DESCRIPTION
## Summary
- rework layout so photo and name share the top of the card and ratings appear beneath

## Testing
- `npm run build` *(fails: fetch to supabase during build)*

------
https://chatgpt.com/codex/tasks/task_e_684c1e8e2e20832f8b6dd47b99cf01e8