### PR TITLE
Update faculty card styling

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -11,7 +11,7 @@ const specialization =
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
   <article class="card" view-transition-name={`card-${faculty.id}`}>
-    <div class="flex items-start gap-4 mb-2">
+    <div class="flex items-start gap-4 mb-2 h-36">
       <div class="photo-wrapper">
         <img
           src={photoUrl}
@@ -22,12 +22,11 @@ const specialization =
         />
       </div>
 
-      <div class="flex flex-col flex-1">
-        <h3 class="text-lg font-bold">{faculty.name || 'Unknown'}</h3>
+      <div class="flex flex-col flex-1 h-36 overflow-hidden">
+        <h3 class="text-lg font-bold mb-1">{faculty.name || 'Unknown'}</h3>
         {specialization && (
-          <p class="clamp-three-lines text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-sm text-gray-500 dark:text-gray-300 leading-snug overflow-hidden flex-grow">
             {specialization}
-
           </p>
         )}
       </div>


### PR DESCRIPTION
## Summary
- tweak FacultyCard style so specialization text fills space next to photo

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c268dfedc832fa0f0be02c44b1d3a