### PR TITLE
Update faculty card styling

### DIFF
--- a/public/clampSpecialization.js
+++ b/public/clampSpecialization.js
@@ -1,0 +1,16 @@
+(function(){
+  function adjust(card){
+    const nameEl = card.querySelector('.faculty-name');
+    const specEl = card.querySelector('.faculty-spec');
+    if(!nameEl || !specEl) return;
+    const lh = parseFloat(getComputedStyle(nameEl).lineHeight);
+    const lines = Math.round(nameEl.offsetHeight / lh);
+    if(lines > 1){
+      specEl.classList.remove('clamp-five-lines');
+      specEl.classList.add('clamp-four-lines');
+    }
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-faculty-card]').forEach(adjust);
+  });
+})();

--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -10,8 +10,8 @@ const specialization =
   faculty.department;
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
-  <article class="card" view-transition-name={`card-${faculty.id}`}>
-    <div class="flex items-start gap-4 mb-2">
+  <article class="card" view-transition-name={`card-${faculty.id}`} data-faculty-card>
+    <div class="flex items-start gap-4 mb-2 h-36">
       <div class="photo-wrapper">
         <img
           src={photoUrl}
@@ -22,12 +22,11 @@ const specialization =
         />
       </div>
 
-      <div class="flex flex-col flex-1">
-        <h3 class="text-lg font-bold">{faculty.name || 'Unknown'}</h3>
+      <div class="flex flex-col flex-1 h-36 overflow-hidden">
+        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name">{faculty.name || 'Unknown'}</h3>
         {specialization && (
-          <p class="clamp-three-lines text-xs text-gray-600 dark:text-gray-400">
+          <p class="text-sm text-gray-500 dark:text-gray-300 leading-snug overflow-hidden flex-grow faculty-spec clamp-five-lines">
             {specialization}
-
           </p>
         )}
       </div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -15,6 +15,7 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <script type="module" src="/viewTransitions.js"></script>
   <script type="module" src="/darkMode.js"></script>
   <script type="module" src="/ratingSlider.js"></script>
+  <script type="module" src="/clampSpecialization.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-black dark:to-gray-900 text-gray-900 dark:text-gray-100">
  

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -28,6 +28,23 @@
   min-height: 3.75rem;
 }
 
+/* Additional clamp utilities for faculty cards */
+.clamp-four-lines {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  min-height: 5rem;
+}
+
+.clamp-five-lines {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  min-height: 6.25rem;
+}
+
 /* Styles for interactive rating sliders */
 .rating-slider {
   -webkit-appearance: none;


### PR DESCRIPTION
## Summary
- add new clamp utility classes for 4 & 5 lines
- apply dynamic clamp logic to specialization text via small script
- clamp faculty names to two lines

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c268dfedc832fa0f0be02c44b1d3a