### PR TITLE
Fix specialization clamp height

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,11 +32,13 @@
 .clamp-four-lines {
   overflow: hidden;
   display: -webkit-box;
- 
+
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
   line-clamp: 4;
-  
+  /* Reserve space so cards stay uniform when text is shorter */
+  min-height: 5rem;
+
 }
 
 


### PR DESCRIPTION
## Summary
- adjust `.clamp-four-lines` style so cards stay uniform

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e67bdb0832fa96641a6aeb2ef87