### PR TITLE
Fix specialization display

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -2,12 +2,20 @@
 import RatingWidget from './RatingWidget.tsx';
 const { faculty } = Astro.props;
 const photoUrl = faculty.photo_url || faculty.photo;
-const specialization =
+const specializationRaw =
   faculty.specialization ||
   faculty.specialisation ||
   faculty.specializations ||
   faculty.dept ||
   faculty.department;
+
+let specialization = specializationRaw;
+if (specializationRaw) {
+  const words = specializationRaw.split(/\s+/);
+  if (words.length > 12) {
+    specialization = words.slice(0, 12).join(' ') + '...';
+  }
+}
 ---
 <a href={`/faculty/${faculty.id}`} class="block" data-id={faculty.id} data-name={faculty.name}>
   <article class="card" view-transition-name={`card-${faculty.id}`}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -32,11 +32,13 @@
 .clamp-four-lines {
   overflow: hidden;
   display: -webkit-box;
- 
+
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
   line-clamp: 4;
-  
+  /* Reserve space so cards stay uniform when text is shorter */
+  min-height: 5rem;
+
 }
 
 


### PR DESCRIPTION
## Summary
- clip faculty specialization text after 12 words

## Testing
- `npm run build` *(fails: fetch to supabase blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684c2e67bdb0832fa96641a6aeb2ef87