### PR TITLE
Refine faculty card layout

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -1,5 +1,5 @@
 ---
-import RatingWidget from './RatingWidget.tsx';
+import { getColor } from './RatingWidget.tsx';
 const { faculty } = Astro.props;
 const photoUrl = faculty.photo_url || faculty.photo;
 const specializationRaw =
@@ -30,7 +30,7 @@ if (specializationRaw) {
         />
       </div>
 
-      <div class="flex flex-col flex-1 h-36 overflow-hidden">
+      <div class="flex-none flex flex-col h-36 overflow-hidden border border-gray-300 dark:border-gray-600 p-2 w-56">
  
         <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name">{faculty.name || 'Unknown'}</h3>
         {specialization && (
@@ -41,17 +41,20 @@ if (specializationRaw) {
         )}
       </div>
     </div>
-    <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.teaching_rating} client:load />
+    <div class="flex justify-center gap-2 mb-2 w-full">
+      <div class={`p-2 rounded-lg w-20 flex flex-col items-center gap-1 shadow ${getColor(faculty.teaching_rating ?? 0)}`}> 
+        <span class="font-bold text-sm">{(faculty.teaching_rating ?? 0).toFixed(1)}</span>
+        <span class="text-[10px]">{faculty.total_ratings} votes</span>
         <span class="text-xs font-medium">Teaching</span>
       </div>
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.attendance_rating} client:load />
+      <div class={`p-2 rounded-lg w-20 flex flex-col items-center gap-1 shadow ${getColor(faculty.attendance_rating ?? 0)}`}> 
+        <span class="font-bold text-sm">{(faculty.attendance_rating ?? 0).toFixed(1)}</span>
+        <span class="text-[10px]">{faculty.total_ratings} votes</span>
         <span class="text-xs font-medium">Attendance</span>
       </div>
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.correction_rating} client:load />
+      <div class={`p-2 rounded-lg w-20 flex flex-col items-center gap-1 shadow ${getColor(faculty.correction_rating ?? 0)}`}> 
+        <span class="font-bold text-sm">{(faculty.correction_rating ?? 0).toFixed(1)}</span>
+        <span class="text-[10px]">{faculty.total_ratings} votes</span>
         <span class="text-xs font-medium">Correction</span>
       </div>
     </div>

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -6,7 +6,7 @@ interface Props {
   disabled?: boolean;
 }
 
-const getColor = (rating: number) => {
+export const getColor = (rating: number) => {
   if (rating === 5) return 'bg-violet-600 text-white ring-2 ring-violet-300 animate-pulse';
   if (rating > 4) return 'bg-green-600 text-white';
   if (rating > 3.5) return 'bg-green-500 text-white';


### PR DESCRIPTION
## Summary
- export rating color helper
- redesign faculty cards

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3a8b113c832fbd2b09003059e96e