### PR TITLE
Add detailed star rating toggle

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -1,5 +1,5 @@
 ---
-import RatingWidget from './RatingWidget.tsx';
+import FacultyRatings from './FacultyRatings.tsx';
 const { faculty } = Astro.props;
 const photoUrl = faculty.photo_url || faculty.photo;
 const specializationRaw =
@@ -41,20 +41,13 @@ if (specializationRaw) {
         )}
       </div>
     </div>
-    <div class="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.teaching_rating} client:load />
-        <span class="text-xs font-medium">Teaching</span>
-      </div>
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.attendance_rating} client:load />
-        <span class="text-xs font-medium">Attendance</span>
-      </div>
-      <div class="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-        <RatingWidget rating={faculty.correction_rating} client:load />
-        <span class="text-xs font-medium">Correction</span>
-      </div>
-    </div>
+    <FacultyRatings
+      teaching={faculty.teaching_rating}
+      attendance={faculty.attendance_rating}
+      correction={faculty.correction_rating}
+      count={faculty.total_ratings}
+      client:load
+    />
     <p class="text-sm text-gray-500 dark:text-gray-400">Rated by {faculty.total_ratings} student{faculty.total_ratings === 1 ? '' : 's'}</p>
   </article>
 </a>

--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import RatingWidget from './RatingWidget';
+
+type Props = {
+  teaching: number | null | undefined;
+  attendance: number | null | undefined;
+  correction: number | null | undefined;
+  count?: number | null | undefined;
+};
+
+function Star({ filled }: { filled: boolean }) {
+  return (
+    <svg
+      className={`w-4 h-4 ${filled ? 'text-yellow-400' : 'text-gray-300'}`}
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path d="M9.049 2.927a1 1 0 011.902 0l1.286 3.959a1 1 0 00.95.69h4.167c.969 0 1.371 1.24.588 1.81l-3.374 2.454a1 1 0 00-.364 1.118l1.286 3.959c.3.921-.755 1.688-1.538 1.118L10 13.347l-3.374 2.454c-.782.57-1.837-.197-1.538-1.118l1.286-3.959a1 1 0 00-.364-1.118L2.636 9.386c-.782-.57-.38-1.81.588-1.81h4.167a1 1 0 00.95-.69l1.286-3.96z" />
+    </svg>
+  );
+}
+
+function StarRow({ label, value, count }: { label: string; value: number; count?: number | null | undefined }) {
+  const full = Math.floor(value);
+  const half = value - full >= 0.5;
+  return (
+    <div className="flex items-center justify-between gap-2">
+      <span className="text-sm font-semibold flex-1">{label}</span>
+      <span className="flex">
+        {[1,2,3,4,5].map(i => (
+          <Star key={i} filled={i <= full || (i === full + 1 && half)} />
+        ))}
+      </span>
+      <span className="text-xs ml-1 w-8 text-right">{value.toFixed(1)}</span>
+      {typeof count === 'number' && (
+        <span className="text-xs text-gray-500 flex items-center gap-1 ml-1">
+          <svg className="w-3 h-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+          </svg>
+          {count}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export default function FacultyRatings({ teaching, attendance, correction, count }: Props) {
+  const [detailed, setDetailed] = useState(false);
+  return (
+    <div>
+      <div className="flex justify-end mb-1">
+        <button
+          type="button"
+          onClick={() => setDetailed(!detailed)}
+          className="text-xs text-blue-600 hover:underline"
+        >
+          {detailed ? 'Compact' : 'Detailed'}
+        </button>
+      </div>
+      {detailed ? (
+        <div className="flex flex-col gap-1 mb-2">
+          <StarRow label="Teaching" value={typeof teaching === 'number' ? teaching : 0} count={count} />
+          <StarRow label="Attendance" value={typeof attendance === 'number' ? attendance : 0} count={count} />
+          <StarRow label="Correction" value={typeof correction === 'number' ? correction : 0} count={count} />
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
+          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+            <RatingWidget rating={teaching} />
+            <span className="text-xs font-medium">Teaching</span>
+          </div>
+          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+            <RatingWidget rating={attendance} />
+            <span className="text-xs font-medium">Attendance</span>
+          </div>
+          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
+            <RatingWidget rating={correction} />
+            <span className="text-xs font-medium">Correction</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `FacultyRatings` React component to toggle between compact rating widgets and detailed star rows
- use the new ratings component in `FacultyCard.astro`

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4028853c832fbeb4198e932ea3e7