### PR TITLE
Improve rating UI defaults

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -57,7 +57,7 @@ function getTextColor(rating: number) {
 }
 
 export default function FacultyRatings({ teaching, attendance, correction, count }: Props) {
-  const [detailed, setDetailed] = useState(true);
+  const [detailed, setDetailed] = useState(false);
 
   return (
     <div>
@@ -81,14 +81,38 @@ export default function FacultyRatings({ teaching, attendance, correction, count
           <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
             <RatingWidget rating={teaching} />
             <span className="text-xs font-medium">Teaching</span>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
           <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
             <RatingWidget rating={attendance} />
             <span className="text-xs font-medium">Attendance</span>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
           <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
             <RatingWidget rating={correction} />
             <span className="text-xs font-medium">Correction</span>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- default to compact rating view
- show total rating count and icon in compact view

## Testing
- `npm run build` *(fails: fetch failed during build but build still completed)*

------
https://chatgpt.com/codex/tasks/task_e_684c49507034832fb18141231bff0f0d