### PR TITLE
Simplify rating count display

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -57,7 +57,7 @@ function getTextColor(rating: number) {
 }
 
 export default function FacultyRatings({ teaching, attendance, correction, count }: Props) {
-  const [detailed, setDetailed] = useState(true);
+  const [detailed, setDetailed] = useState(false);
 
   return (
     <div>
@@ -78,17 +78,47 @@ export default function FacultyRatings({ teaching, attendance, correction, count
         </div>
       ) : (
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
-          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={teaching} />
-            <span className="text-xs font-medium">Teaching</span>
+          <div className="flex flex-col items-center gap-1">
+            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+              <RatingWidget rating={teaching} />
+              <span className="text-xs font-medium">Teaching</span>
+            </div>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
-          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={attendance} />
-            <span className="text-xs font-medium">Attendance</span>
+          <div className="flex flex-col items-center gap-1">
+            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+              <RatingWidget rating={attendance} />
+              <span className="text-xs font-medium">Attendance</span>
+            </div>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
-          <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow">
-            <RatingWidget rating={correction} />
-            <span className="text-xs font-medium">Correction</span>
+          <div className="flex flex-col items-center gap-1">
+            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+              <RatingWidget rating={correction} />
+              <span className="text-xs font-medium">Correction</span>
+            </div>
+            {typeof count === 'number' && (
+              <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
+                </svg>
+                {count}
+              </span>
+            )}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- remove the count placement toggle and keep counts below rating boxes
- ensure boxes share equal size and keep compact view as default

## Testing
- `npm ci`
- `npm run build` *(fails fetching supabase data but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684c49507034832fb18141231bff0f0d