### PR TITLE
Fix FacultyRatings state error

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -64,13 +64,6 @@ export default function FacultyRatings({ teaching, attendance, correction, count
       <div className="flex justify-between mb-1">
         <button
           type="button"
-          onClick={() => setInside(!inside)}
-          className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
-        >
-          {inside ? 'Counts inside' : 'Counts below'}
-        </button>
-        <button
-          type="button"
           onClick={() => setDetailed(!detailed)}
           className="text-xs px-2 py-1 rounded bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600"
         >
@@ -85,7 +78,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
         </div>
       ) : (
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
- 
+
           <div className="flex flex-col items-center gap-1">
             <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={teaching} />
@@ -93,7 +86,6 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             </div>
             {typeof count === 'number' && (
               <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
- 
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
                 </svg>
@@ -101,7 +93,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
               </span>
             )}
           </div>
- 
+
           <div className="flex flex-col items-center gap-1">
             <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={attendance} />
@@ -109,7 +101,6 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             </div>
             {typeof count === 'number' && (
               <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
- 
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
                 </svg>
@@ -117,7 +108,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
               </span>
             )}
           </div>
- 
+
           <div className="flex flex-col items-center gap-1">
             <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={correction} />
@@ -125,7 +116,6 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             </div>
             {typeof count === 'number' && (
               <span className="text-[10px] text-gray-400 flex items-center gap-1 mt-1">
- 
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path d="M13 7a3 3 0 11-6 0 3 3 0 016 0zM5 13a4 4 0 018 0v1H5v-1zM15 12h2a2 2 0 012 2v2h-4v-4z" />
                 </svg>


### PR DESCRIPTION
## Summary
- remove unused count toggle state in FacultyRatings
- always show counts below rating cards

## Testing
- `npm install`
- `npm run build` *(fails: Error fetching lists but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684c52ec9fa8832f9c958abda192fba3