### PR TITLE
Adjust faculty card rating styles

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -82,7 +82,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={teaching} />
               <span className="text-xs font-medium">Teaching</span>
             </div>
@@ -97,7 +97,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={attendance} />
               <span className="text-xs font-medium">Attendance</span>
             </div>
@@ -112,7 +112,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="p-2 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={correction} />
               <span className="text-xs font-medium">Correction</span>
             </div>

--- a/src/components/RateFaculty.tsx
+++ b/src/components/RateFaculty.tsx
@@ -32,9 +32,12 @@ export default function RateFaculty() {
   const [teaching, setTeaching] = useState(0);
   const [attendance, setAttendance] = useState(0);
   const [correction, setCorrection] = useState(0);
+  const [ratedAverage, setRatedAverage] = useState<number | null>(null);
 
   const submit = () => {
     alert('Thanks for rating!');
+    const avg = (teaching + attendance + correction) / 3;
+    setRatedAverage(avg);
     setOpen(false);
     setTeaching(0);
     setAttendance(0);
@@ -46,9 +49,13 @@ export default function RateFaculty() {
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className="mt-2 px-2 py-1 rounded bg-violet-600 text-white hover:bg-violet-700"
+        className={`mt-2 px-2 py-0.5 rounded text-sm ${
+          ratedAverage === null
+            ? 'bg-gray-400 text-white hover:bg-gray-500'
+            : 'bg-yellow-300 text-gray-900'
+        }`}
       >
-        Rate
+        {ratedAverage === null ? 'Rate' : ratedAverage.toFixed(1)}
       </button>
     );
   }


### PR DESCRIPTION
## Summary
- tweak rating tiles padding on larger screens
- update Rate button styles and behavior

## Testing
- `npm run build` *(fails: fetch failed during build but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684c5c354d34832f8dd2952fb2c9eaed