### PR TITLE
Add animated heart favorites

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -1,6 +1,7 @@
 ---
 import FacultyRatings from './FacultyRatings.tsx';
 import RateFaculty from './RateFaculty.tsx';
+import HeartButton from './HeartButton.tsx';
 const { faculty } = Astro.props;
 const photoUrl = faculty.photo_url || faculty.photo;
 const specializationRaw =
@@ -49,4 +50,5 @@ if (specializationRaw) {
       client:visible
     />
     <RateFaculty client:visible />
+    <HeartButton client:visible />
 </article>

--- a/src/components/HeartButton.tsx
+++ b/src/components/HeartButton.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+
+export default function HeartButton() {
+  const [liked, setLiked] = useState(false);
+  const [animate, setAnimate] = useState(false);
+
+  const toggle = () => {
+    setLiked(!liked);
+    setAnimate(true);
+  };
+
+  return (
+    <svg
+      onClick={toggle}
+      onAnimationEnd={() => setAnimate(false)}
+      className={`w-6 h-6 cursor-pointer absolute bottom-2 right-2 transition-colors ${
+        liked ? 'text-red-500' : 'text-gray-400'
+      } ${animate ? 'animate-pop' : ''}`}
+      viewBox="0 0 24 24"
+      fill={liked ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+    </svg>
+  );
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -4,7 +4,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply bg-gray-50 dark:bg-gray-100 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
+  @apply relative bg-gray-50 dark:bg-gray-100 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
 .card:hover {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -8,9 +8,15 @@ module.exports = {
           '0%': { opacity: '0', transform: 'scale(0.95)' },
           '100%': { opacity: '1', transform: 'scale(1)' },
         },
+        pop: {
+          '0%': { transform: 'scale(0.5)' },
+          '50%': { transform: 'scale(1.2)' },
+          '100%': { transform: 'scale(1)' },
+        },
       },
       animation: {
         fade: 'fade 0.3s ease-in-out',
+        pop: 'pop 0.3s ease-out',
       },
     },
   },


### PR DESCRIPTION
## Summary
- add HeartButton component for liking faculty
- position HeartButton at bottom-right of each card
- allow absolute positioning by making .card relative
- add `pop` animation to Tailwind config

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5d81d938832fb47f94f0c4f2a38d