### PR TITLE
Fix FacultyCard astro syntax

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -18,7 +18,9 @@ if (specializationRaw) {
     specialization = words.slice(0, 12).join(' ') + '...';
   }
 }
- 
+
+---
+
 <article class="card pb-12">
  
     <div class="flex items-start gap-4 mb-2 h-36">


### PR DESCRIPTION
## Summary
- close the frontmatter section in `FacultyCard.astro`
- keep the `onerror` attribute on one line

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c6772e62c832fbf274c1b0f499a93