### PR TITLE
Increase faculty card vertical space

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -23,7 +23,7 @@ if (specializationRaw) {
 
 <article class="card pb-12">
  
-    <div class="flex items-start gap-4 mb-2 h-36">
+    <div class="flex items-start gap-4 mb-2 h-40">
       <div class="photo-wrapper">
         <img
           src={photoUrl}
@@ -34,7 +34,7 @@ if (specializationRaw) {
         />
       </div>
 
-      <div class="flex flex-col flex-1 h-36 overflow-hidden">
+      <div class="flex flex-col flex-1 h-40 overflow-hidden">
  
         <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-segoe">{faculty.name || 'Unknown'}</h3>
         {specialization && (

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -84,10 +84,12 @@
   @apply w-full h-full object-cover;
 }
 
+
 .photo-wrapper {
 
   /* Increased size with maintained 3:4 ratio and stronger shadow */
-  @apply w-28 h-36 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg ml-2;
+  /* Slightly taller to give the card more vertical room */
+  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg ml-2;
 
 
 }


### PR DESCRIPTION
## Summary
- make the faculty photo wrapper a little taller
- expand the height of the faculty card layout

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c694ceb3c832fa251765d720d995c