### PR TITLE
Update faculty card typography

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -34,11 +34,11 @@ if (specializationRaw) {
 
       <div class="flex flex-col flex-1 h-40 overflow-hidden">
  
-        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-segoe">{faculty.name || 'Unknown'}</h3>
+        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins">{faculty.name || 'Unknown'}</h3>
         {specialization && (
  
 
-          <p class="text-sm italic text-gray-500 dark:text-gray-300 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe">
+          <p class="text-sm italic text-gray-400 dark:text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe">
  
  
             {specialization}

--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -27,7 +27,7 @@ function StarRow({ label, value, count }: { label: string; value: number; count?
   return (
     <div className="flex items-center justify-between gap-2">
  
-      <span className="text-base italic text-gray-500 dark:text-gray-300 flex-1 font-segoe">{label}</span>
+      <span className="text-base text-gray-500 dark:text-gray-300 flex-1 font-segoe">{label}</span>
  
       <span className="flex">
         {[1,2,3,4,5].map(i => (
@@ -87,7 +87,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={teaching} />
  
-              <span className="text-sm italic text-gray-500 dark:text-gray-300 font-segoe">Teaching</span>
+              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Teaching</span>
  
             </div>
             {typeof count === 'number' && (
@@ -104,7 +104,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={attendance} />
  
-              <span className="text-sm italic text-gray-500 dark:text-gray-300 font-segoe">Attendance</span>
+              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Attendance</span>
  
             </div>
             {typeof count === 'number' && (
@@ -121,7 +121,7 @@ export default function FacultyRatings({ teaching, attendance, correction, count
             <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
               <RatingWidget rating={correction} />
  
-              <span className="text-sm italic text-gray-500 dark:text-gray-300 font-segoe">Correction</span>
+              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Correction</span>
  
             </div>
             {typeof count === 'number' && (

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -8,6 +8,9 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width" />
   <title>{title}</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+1" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+2" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+3" />

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -20,6 +20,7 @@ module.exports = {
       },
       fontFamily: {
         segoe: ['"Segoe UI"', 'Helvetica', 'Arial', 'sans-serif'],
+        poppins: ['"Poppins"', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- use Poppins font for faculty names and load it
- lighten specialization text color
- remove italics from rating labels

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c6d4de5f4832f95cc5b8a5ccee9b2