### PR TITLE
Render search bar in header

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,5 +1,6 @@
 ---
 import '../styles/global.css';
+import SearchBar from '../components/SearchBar.tsx';
 const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -26,7 +27,7 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
       <h1 class="text-2xl font-bold">{headerTitle}</h1>
       <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-gray-700">🌓</button>
     </div>
-    <slot name="search"></slot>
+    <SearchBar client:load />
   </header>
   <main class="container mx-auto p-4"><slot /></main>
 </body>


### PR DESCRIPTION
## Summary
- move `SearchBar` import and usage into the `Base` layout so the header always renders the search bar
- drop now-unneeded `SearchBar` import from `index.astro`

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c7362bff0832fbb0d18dd7c826a53