### PR TITLE
Fix search card width

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -75,7 +75,10 @@ export default function SearchBar() {
       {!loading && !error && query.trim() && results.length === 0 && (
         <p className="text-gray-500">No results found.</p>
       )}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {/* Mirror the card grid used on the listing page so each card keeps
+          the same width. Even if there is only one search result, its
+          dimensions won't stretch across the page. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32">


### PR DESCRIPTION
## Summary
- keep search result cards from stretching by matching the main listing grid
- clarify code comment

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c7a5ad1e8832f81eb1f9a5906083c