### PR TITLE
Fix card grid width

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -75,7 +75,8 @@ export default function SearchBar() {
       {!loading && !error && query.trim() && results.length === 0 && (
         <p className="text-gray-500">No results found.</p>
       )}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {/* Mirror the listing page grid so each card keeps the same width. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const list = faculty;
 <Base>
   <DetailedToggle client:load />
   <SearchBar slot="search" client:load />
-  <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
     {paginate(list, page).map(f => (
       <FacultyCard faculty={f} />
     ))}

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -19,7 +19,7 @@ if (page < 1 || page > pages) {
 ---
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle client:load />
-  <div class="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
+  <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
     {paginate(faculty, page).map(f => (
       <FacultyCard faculty={f} />
     ))}


### PR DESCRIPTION
## Summary
- keep search results using the same grid layout
- show only three cards per row everywhere

## Testing
- `npm install`
- `npm run build` *(fails to fetch lists)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a5ad1e8832f81eb1f9a5906083c