### PR TITLE
Fix card grid width

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -75,7 +75,8 @@ export default function SearchBar() {
       {!loading && !error && query.trim() && results.length === 0 && (
         <p className="text-gray-500">No results found.</p>
       )}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {/* Use the same grid as the main listings so cards keep a fixed width. */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 md:grid-cols-4 gap-4">
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32">


### PR DESCRIPTION
## Summary
- use same grid as the main listing, with 4 cards per row at larger screens
- search results also keep 4-card layout

## Testing
- `npm install`
- `npm run build` *(fails to fetch lists)*

------
https://chatgpt.com/codex/tasks/task_e_684c7a5ad1e8832f81eb1f9a5906083c