### PR TITLE
Add fixed card layout demo

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -27,7 +27,7 @@ const correctionCount =
   faculty.num_correction_ratings ?? faculty.numCorrectionRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 
 ---
-<article class="card pb-32"> 
+<article class="card pb-32 w-72">
     <div class="flex items-start gap-4 mb-2 h-40">
       <div class="photo-wrapper">
         <img

--- a/src/components/FixedCardLayout.tsx
+++ b/src/components/FixedCardLayout.tsx
@@ -1,0 +1,37 @@
+import FacultyRatings from './FacultyRatings';
+
+// Simple faculty card using fixed width
+export function FacultyCardExample() {
+  return (
+    <div className="w-72 rounded-lg shadow-lg bg-white dark:bg-gray-800 overflow-hidden p-4 flex flex-col gap-2">
+      <img
+        src="https://placehold.co/200x250"
+        alt="Prof. Jane Doe"
+        className="w-full h-48 object-cover rounded"
+      />
+      <h3 className="text-lg font-semibold font-poppins">Prof. Jane Doe</h3>
+      <p className="text-sm italic text-gray-500">Computer Science</p>
+      <FacultyRatings teaching={4.5} attendance={4.2} correction={4.7} />
+    </div>
+  );
+}
+
+export default function FixedCardLayout() {
+  return (
+    <>
+      <h2 className="text-2xl font-bold mb-4">Centered Layout</h2>
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-6">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <FacultyCardExample key={`c${i}`} />
+        ))}
+      </div>
+
+      <h2 className="text-2xl font-bold mt-8 mb-4">Left Aligned Layout</h2>
+      <div className="flex flex-wrap justify-start gap-x-4 gap-y-6">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <FacultyCardExample key={`l${i}`} />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -75,11 +75,11 @@ export default function SearchBar() {
       {!loading && !error && query.trim() && results.length === 0 && (
         <p className="text-gray-500">No results found.</p>
       )}
-      {/* Use the same grid as the main listings so cards keep a fixed width. */}
-      <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+      {/* Wrap search results with fixed-width cards */}
+      <div className="flex flex-wrap justify-center gap-x-4 gap-y-6">
         {results.map((item) => (
 
-          <article key={item.name} className="card pb-32">
+          <article key={item.name} className="card pb-32 w-72">
             <div className="flex items-start gap-4 mb-2 h-40">
               <div className="photo-wrapper">
                 <img

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,10 +12,12 @@ const list = faculty;
 <Base>
   <DetailedToggle client:load />
   <SearchBar slot="search" client:load />
-  <!-- Keep four cards per row on wider screens for consistent sizing -->
-  <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+  <!-- Wrap cards with fixed width using flex -->
+  <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
     {paginate(list, page).map(f => (
-      <FacultyCard faculty={f} />
+      <div class="w-72">
+        <FacultyCard faculty={f} />
+      </div>
     ))}
   </div>
   <nav class="mt-4 flex justify-center gap-2">

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -19,10 +19,12 @@ if (page < 1 || page > pages) {
 ---
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle client:load />
-  <!-- Keep four cards per row on wider screens for consistent sizing -->
-  <div class="grid grid-cols-1 sm:grid-cols-4 gap-4">
+  <!-- Wrap cards with fixed width using flex -->
+  <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
     {paginate(faculty, page).map(f => (
-      <FacultyCard faculty={f} />
+      <div class="w-72">
+        <FacultyCard faculty={f} />
+      </div>
     ))}
   </div>
   <nav class="mt-4 flex justify-center gap-2">


### PR DESCRIPTION
## Summary
- add a React example showing how to keep card width fixed
- wrap all faculty card listings with a fixed-width flex layout

## Testing
- `npm install`
- `npm run build` *(fails to fetch data but build succeeds)*

------
https://chatgpt.com/codex/tasks/task_e_684c82e449c8832fb1daf9282010070e