### PR TITLE
Add adjustable card width slider

### DIFF
--- a/public/widthSlider.js
+++ b/public/widthSlider.js
@@ -1,0 +1,16 @@
+(function() {
+  function setup() {
+    const slider = document.getElementById('width-slider');
+    const valueEl = document.getElementById('width-value');
+    if (!slider) return;
+    const root = document.documentElement;
+    const update = () => {
+      const val = slider.value;
+      root.style.setProperty('--card-width', val + 'px');
+      if (valueEl) valueEl.textContent = val + 'px';
+    };
+    slider.addEventListener('input', update);
+    update();
+  }
+  document.addEventListener('DOMContentLoaded', setup);
+})();

--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -27,7 +27,7 @@ const correctionCount =
   faculty.num_correction_ratings ?? faculty.numCorrectionRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 
 ---
-<article class="card pb-32 w-72">
+<article class="card pb-32 card-wrapper">
     <div class="flex items-start gap-4 mb-2 h-40">
       <div class="photo-wrapper">
         <img

--- a/src/components/FixedCardLayout.tsx
+++ b/src/components/FixedCardLayout.tsx
@@ -3,7 +3,7 @@ import FacultyRatings from './FacultyRatings';
 // Simple faculty card using fixed width
 export function FacultyCardExample() {
   return (
-    <div className="w-72 rounded-lg shadow-lg bg-white dark:bg-gray-800 overflow-hidden p-4 flex flex-col gap-2">
+    <div className="card-wrapper rounded-lg shadow-lg bg-white dark:bg-gray-800 overflow-hidden p-4 flex flex-col gap-2">
       <img
         src="https://placehold.co/200x250"
         alt="Prof. Jane Doe"

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -79,7 +79,7 @@ export default function SearchBar() {
       <div className="flex flex-wrap justify-center gap-x-4 gap-y-6">
         {results.map((item) => (
 
-          <article key={item.name} className="card pb-32 w-72">
+          <article key={item.name} className="card pb-32 card-wrapper">
             <div className="flex items-start gap-4 mb-2 h-40">
               <div className="photo-wrapper">
                 <img

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -19,15 +19,20 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <script type="module" src="/viewTransitions.js"></script>
   <script type="module" src="/darkMode.js"></script>
   <script type="module" src="/ratingSlider.js"></script>
+  <script type="module" src="/widthSlider.js"></script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-black dark:to-gray-900 text-gray-900 dark:text-gray-100">
- 
+
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
     <div class="w-full flex justify-center items-center">
       <h1 class="text-2xl font-bold">{headerTitle}</h1>
       <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-gray-700">🌓</button>
     </div>
     <SearchBar client:load />
+    <div class="flex items-center gap-2 mt-2">
+      <input id="width-slider" type="range" min="200" max="400" value="288" class="w-48" />
+      <span id="width-value" class="text-sm"></span>
+    </div>
   </header>
   <main class="container mx-auto p-4"><slot /></main>
 </body>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,7 +15,7 @@ const list = faculty;
   <!-- Wrap cards with fixed width using flex -->
   <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
     {paginate(list, page).map(f => (
-      <div class="w-72">
+      <div class="card-wrapper">
         <FacultyCard faculty={f} />
       </div>
     ))}

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -22,7 +22,7 @@ if (page < 1 || page > pages) {
   <!-- Wrap cards with fixed width using flex -->
   <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
     {paginate(faculty, page).map(f => (
-      <div class="w-72">
+      <div class="card-wrapper">
         <FacultyCard faculty={f} />
       </div>
     ))}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --card-width: 288px;
+}
+
 /* Critical styles for cards */
 .card {
   @apply relative bg-gray-50 dark:bg-gray-100 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
@@ -98,4 +102,9 @@ html.no-scroll,
 body.no-scroll {
   overflow: hidden;
   touch-action: none;
+}
+
+/* Wrapper for faculty cards with adjustable width */
+.card-wrapper {
+  width: var(--card-width, 18rem);
 }


### PR DESCRIPTION
## Summary
- allow adjusting the faculty card width on the site
- load new `widthSlider.js` script and slider UI in Base layout
- add card wrapper utility and CSS custom property
- update pages and components to use the new wrapper

## Testing
- `npx -y astro build` *(fails: Cannot find module 'astro/config')*

------
https://chatgpt.com/codex/tasks/task_e_684c86bb11f0832fa75a69bf5d3d7806