### PR TITLE
Adjust faculty card spacing

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -76,7 +76,7 @@ export default function SearchBar() {
         <p className="text-gray-500">No results found.</p>
       )}
       {/* Display search results in a three-column grid */}
-      <div className="grid grid-cols-3 gap-x-4 gap-y-6 justify-items-center">
+      <div className="grid grid-cols-3 gap-x-4 gap-y-8 justify-items-center">
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32 card-wrapper">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,7 +13,7 @@ const list = faculty;
   <DetailedToggle client:load />
   <SearchBar slot="search" client:load />
   <!-- Wrap cards with fixed width using flex -->
-  <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
+  <div class="flex flex-wrap justify-center gap-x-4 gap-y-8">
     {paginate(list, page).map(f => (
       <div class="card-wrapper">
         <FacultyCard faculty={f} />

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -20,7 +20,7 @@ if (page < 1 || page > pages) {
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle client:load />
   <!-- Wrap cards with fixed width using flex -->
-  <div class="flex flex-wrap justify-center gap-x-4 gap-y-6">
+  <div class="flex flex-wrap justify-center gap-x-4 gap-y-8">
     {paginate(faculty, page).map(f => (
       <div class="card-wrapper">
         <FacultyCard faculty={f} />


### PR DESCRIPTION
## Summary
- increase `gap-y` to give more space between faculty cards on the home UI and paginated pages
- use the same spacing in search results

## Testing
- `npm run build` *(fails: fetch failed during build but pages were generated)*

------
https://chatgpt.com/codex/tasks/task_e_684c8efb7030832f855c45fe3b486952