### PR TITLE
Make cards responsive

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -75,8 +75,8 @@ export default function SearchBar() {
       {!loading && !error && query.trim() && results.length === 0 && (
         <p className="text-gray-500">No results found.</p>
       )}
-      {/* Display search results in a three-column grid */}
-      <div className="grid grid-cols-3 gap-x-4 gap-y-8 justify-items-center">
+      {/* Display search results in a responsive grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8 justify-items-center">
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32 card-wrapper">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -106,5 +106,7 @@ body.no-scroll {
 
 /* Wrapper for faculty cards with adjustable width */
 .card-wrapper {
-  width: var(--card-width, 18rem);
+  /* Stretch up to the configured width but shrink on small screens */
+  max-width: var(--card-width, 18rem);
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- respect small screens by making `.card-wrapper` width max 400px and shrinkable
- update search result grid so it shows 1 column on mobile, 2 on medium, 3 on wide screens

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c90a587b0832f85201169b8f73437