### PR TITLE
Update dark mode styling

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -65,7 +65,7 @@ export default function SearchBar() {
     <div className="mb-6">
       <input
         type="text"
-        className="w-full px-4 py-2 border rounded-lg mb-4"
+        className="w-full px-4 py-2 border rounded-lg mb-4 dark:bg-seablue dark:text-white"
         placeholder="Search..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -20,12 +20,12 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <script type="module" src="/darkMode.js"></script>
   <script type="module" src="/ratingSlider.js"></script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-black dark:to-gray-900 text-gray-900 dark:text-gray-100">
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:to-darkpurple text-gray-900 dark:text-gray-100">
 
-  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
+  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2 dark:bg-darkblue">
     <div class="w-full flex justify-center items-center">
       <h1 class="text-2xl font-bold">{headerTitle}</h1>
-      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-gray-700">🌓</button>
+      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-pink-600">🌓</button>
     </div>
     <SearchBar client:load />
     

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,7 +8,7 @@
 
 /* Critical styles for cards */
 .card {
-  @apply relative bg-gray-50 dark:bg-gray-100 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
+  @apply relative bg-gray-50 dark:bg-darkblue dark:text-white p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
 .card:hover {
@@ -57,6 +57,9 @@
   outline: none;
   cursor: pointer;
 }
+.dark .rating-slider {
+  background: #0284c7;
+}
 .rating-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
@@ -73,8 +76,8 @@
   background: var(--slider-color, #7c3aed);
   cursor: pointer;
 }
-.rating-bubble { 
-  @apply absolute -top-6 left-1/2 -translate-x-1/2 px-2 py-0.5 text-sm font-semibold rounded bg-black text-white pointer-events-none hidden;
+.rating-bubble {
+  @apply absolute -top-6 left-1/2 -translate-x-1/2 px-2 py-0.5 text-sm font-semibold rounded bg-black dark:bg-pink-600 text-white pointer-events-none hidden;
 }
 .rating-value {
   min-width: 2rem;
@@ -89,11 +92,11 @@
 }
 
 
-.photo-wrapper {
 
+.photo-wrapper {
   /* Increased size with maintained 3:4 ratio and stronger shadow */
   /* Slightly taller to give the card more vertical room */
-  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-gray-900 shadow-lg ml-2;
+  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-darkblue shadow-lg ml-2;
 
 
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,6 +22,11 @@ module.exports = {
         segoe: ['"Segoe UI"', 'Helvetica', 'Arial', 'sans-serif'],
         poppins: ['"Poppins"', 'sans-serif'],
       },
+      colors: {
+        darkpurple: '#0a0116',
+        seablue: '#0284c7',
+        darkblue: '#1e3a8a',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- customize color palette with `darkpurple`, `seablue` and `darkblue`
- apply new palette in `Base` layout
- style search input for dark mode
- update card and slider styles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c92060724832fbbb12df3db18283b