### PR TITLE
Fix rating box size in dark mode

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -86,7 +86,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]">
               <RatingWidget rating={teaching} />
  
               <span className="text-sm text-gray-500 dark:text-[#FF00C8] font-segoe">Teaching</span>
@@ -103,7 +103,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]">
               <RatingWidget rating={attendance} />
  
               <span className="text-sm text-gray-500 dark:text-[#00FFD8] font-segoe">Attendance</span>
@@ -120,7 +120,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]">
               <RatingWidget rating={correction} />
  
               <span className="text-sm text-gray-500 dark:text-[#FFD500] font-segoe">Correction</span>


### PR DESCRIPTION
## Summary
- adjust rating container classes to remove dark mode width/height overrides

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d25d43084832f9940b56046d1ee3d