### PR TITLE
Refine dark mode toggle and rate button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "@types/react-dom": "^19.1.6",
         "astro": "^4.16.18",
         "autoprefixer": "^10.4.21",
-        "minisearch": "^7.1.2",
         "postcss": "^8.5.5",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "tailwindcss": "^3.4.4",
+        "tailwindcss-filters": "^3.0.0",
         "typescript": "^5.8.3"
       }
     },
@@ -4348,6 +4348,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-6.0.0.tgz",
@@ -5282,12 +5288,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/minisearch": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.1.2.tgz",
-      "integrity": "sha512-R1Pd9eF+MD5JYDDSPAp/q1ougKglm14uEkPMvQ/05RGmx6G9wvmLTrTI/Q5iPNJLYqNdsDQ7qTGIcNWR+FrHmA==",
-      "license": "MIT"
     },
     "node_modules/minizlib": {
       "version": "3.0.2",
@@ -6685,6 +6685,16 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss-filters": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss-filters/-/tailwindcss-filters-3.0.0.tgz",
+      "integrity": "sha512-xhortqs8fSp9id17EnneYhmruA5DfU6K0zvN6/mgDlEXKaHthjXlR74Ta+4lrX5Lp7tp6YigB09WO0TOWn7VEQ==",
+      "deprecated": "Use Tailwind's filter utilities",
+      "license": "ISC",
+      "dependencies": {
+        "lodash": "^4.17.15"
       }
     },
     "node_modules/tailwindcss/node_modules/glob-parent": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "tailwindcss": "^3.4.4",
+    "tailwindcss-filters": "^3.0.0",
     "typescript": "^5.8.3"
   }
 }

--- a/public/assets/neon-pattern.svg
+++ b/public/assets/neon-pattern.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#00ffd8"/>
+      <stop offset="100%" stop-color="#ff00c8"/>
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" fill="url(#grad)" opacity="0.2"/>
+</svg>

--- a/src/components/DarkModeToggle.tsx
+++ b/src/components/DarkModeToggle.tsx
@@ -1,0 +1,28 @@
+import useDarkMode from '../hooks/useDarkMode';
+
+interface Props {
+  className?: string;
+}
+
+export default function DarkModeToggle({ className = '' }: Props) {
+  const { isDark, toggleDark } = useDarkMode();
+
+  return (
+    <button
+      onClick={toggleDark}
+      className={`p-2 rounded-md ${className} ${isDark ? 'bg-gray-800' : 'bg-gray-200'}`}
+      aria-label="Toggle dark mode"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        fill="currentColor"
+        className="w-6 h-6 text-gray-700 dark:text-[#00FFD8]"
+      >
+        <path
+          d="M21 12.79A9 9 0 0111.21 3 7 7 0 1012 21a9 9 0 009-8.21z"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -27,8 +27,8 @@ const correctionCount =
   faculty.num_correction_ratings ?? faculty.numCorrectionRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 
 ---
-<article class="card pb-32 card-wrapper">
-    <div class="flex items-start gap-4 mb-2 h-40">
+<article class="card pb-32 dark:pb-6 card-wrapper">
+    <div class="flex items-start gap-4 mb-2">
       <div class="photo-wrapper">
         <img
           src={photoUrl}
@@ -39,15 +39,11 @@ const correctionCount =
         />
       </div>
 
-      <div class="flex flex-col flex-1 h-40 overflow-hidden">
- 
-        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins">{faculty.name || 'Unknown'}</h3>
-        {specialization && (
- 
+      <div class="flex flex-col flex-1 overflow-hidden">
 
-          <p class="text-sm italic text-gray-400 dark:text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe">
- 
- 
+        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">{faculty.name || 'Unknown'}</h3>
+        {specialization && (
+          <p class="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">
             {specialization}
           </p>
         )}

--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -86,10 +86,10 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]">
               <RatingWidget rating={teaching} />
  
-              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Teaching</span>
+              <span className="text-sm text-gray-500 dark:text-[#FF00C8] font-segoe">Teaching</span>
  
             </div>
             {typeof tCount === 'number' && (
@@ -103,10 +103,10 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]">
               <RatingWidget rating={attendance} />
  
-              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Attendance</span>
+              <span className="text-sm text-gray-500 dark:text-[#00FFD8] font-segoe">Attendance</span>
  
             </div>
             {typeof aCount === 'number' && (
@@ -120,10 +120,10 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 dark:bg-gray-700 flex flex-col items-center gap-1 shadow w-full">
+            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:w-16 dark:h-16 dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]">
               <RatingWidget rating={correction} />
  
-              <span className="text-sm text-gray-500 dark:text-gray-300 font-segoe">Correction</span>
+              <span className="text-sm text-gray-500 dark:text-[#FFD500] font-segoe">Correction</span>
  
             </div>
             {typeof cCount === 'number' && (

--- a/src/components/RateFaculty.tsx
+++ b/src/components/RateFaculty.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import useDarkMode from '../hooks/useDarkMode';
 
 function Star({ filled, onClick }: { filled: boolean; onClick: () => void }) {
   return (
@@ -28,6 +29,7 @@ function StarRow({ label, value, onChange }: { label: string; value: number; onC
 }
 
 export default function RateFaculty() {
+  const { isDark } = useDarkMode();
   const [open, setOpen] = useState(false);
   const [teaching, setTeaching] = useState(0);
   const [attendance, setAttendance] = useState(0);
@@ -49,12 +51,12 @@ export default function RateFaculty() {
       <button
         type="button"
         onClick={() => setOpen(true)}
- 
-        className={`absolute bottom-2 left-2 px-2 py-0.5 rounded text-sm ${
- 
-          ratedAverage === null
-            ? 'bg-gray-400 text-white hover:bg-gray-500'
-            : 'bg-yellow-300 text-gray-900'
+        className={`absolute bottom-2 left-2 rounded text-sm ${
+          isDark
+            ? 'px-2 py-0.5 rounded-full border border-[#00FFD8] text-[#00FFD8] hover:bg-white/10'
+            : ratedAverage === null
+              ? 'bg-gray-400 text-white hover:bg-gray-500 px-2 py-0.5'
+              : 'bg-yellow-300 text-gray-900 px-2 py-0.5'
         }`}
       >
         {ratedAverage === null ? 'Rate' : ratedAverage.toFixed(1)}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -65,7 +65,7 @@ export default function SearchBar() {
     <div className="mb-6">
       <input
         type="text"
-        className="w-full px-4 py-2 border rounded-lg mb-4 dark:bg-seablue dark:text-white"
+        className="w-full h-12 px-4 rounded-md border border-[#1E2230] mb-4 bg-white text-gray-800 placeholder-gray-500 dark:bg-[#0A0F1E] dark:text-[#E4E9F0] dark:placeholder-[#5A5F7D] focus:outline-none focus:ring-2 focus:ring-[#00FFD8]"
         placeholder="Search..."
         value={query}
         onChange={(e) => setQuery(e.target.value)}
@@ -80,7 +80,7 @@ export default function SearchBar() {
         {results.map((item) => (
 
           <article key={item.name} className="card pb-32 card-wrapper">
-            <div className="flex items-start gap-4 mb-2 h-40">
+            <div className="flex items-start gap-4 mb-2">
               <div className="photo-wrapper">
                 <img
                   src={item.photo_url || 'https://placehold.co/300x400?text=No+Photo'}
@@ -93,10 +93,10 @@ export default function SearchBar() {
                   className="faculty-photo"
                 />
               </div>
-              <div className="flex flex-col flex-1 h-40 overflow-hidden">
-                <h3 className="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins">{item.name}</h3>
+              <div className="flex flex-col flex-1 overflow-hidden">
+                <h3 className="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">{item.name}</h3>
                 {item.specialization && (
-                  <p className="text-sm italic text-gray-400 dark:text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe">
+                  <p className="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">
                     {item.specialization}
                   </p>
                 )}

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+export default function useDarkMode() {
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const shouldUseDark = stored ? stored === 'dark' : prefers;
+    document.documentElement.classList.toggle('dark', shouldUseDark);
+    setIsDark(shouldUseDark);
+  }, []);
+
+  function toggleDark() {
+    setIsDark((prev) => {
+      const next = !prev;
+      document.documentElement.classList.toggle('dark', next);
+      localStorage.setItem('theme', next ? 'dark' : 'light');
+      return next;
+    });
+  }
+
+  return { isDark, toggleDark };
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -1,6 +1,7 @@
 ---
 import '../styles/global.css';
 import SearchBar from '../components/SearchBar.tsx';
+import DarkModeToggle from '../components/DarkModeToggle.tsx';
 const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -17,19 +18,25 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+3" />
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+4" />
   <script type="module" src="/viewTransitions.js"></script>
-  <script type="module" src="/darkMode.js"></script>
   <script type="module" src="/ratingSlider.js"></script>
+  <script>
+    const stored = localStorage.getItem('theme');
+    const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
+    if (stored === 'dark' || (!stored && prefers)) {
+      document.documentElement.classList.add('dark');
+    }
+  </script>
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:to-darkpurple text-gray-900 dark:text-gray-100">
 
-  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2 dark:bg-darkblue">
+  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
     <div class="w-full flex justify-center items-center">
-      <h1 class="text-2xl font-bold">{headerTitle}</h1>
-      <button id="dark-mode-toggle" class="absolute right-4 p-2 rounded-lg bg-gray-200 dark:bg-pink-600">🌓</button>
+      <h1 class="text-4xl font-semibold dark:text-[#00FFD8]">{headerTitle}</h1>
+      <DarkModeToggle client:load class="absolute right-4" />
     </div>
     <SearchBar client:load />
     
   </header>
-  <main class="container mx-auto p-4"><slot /></main>
+  <main class="container mx-auto p-4 md:p-8"><slot /></main>
 </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3,12 +3,16 @@
 @tailwind utilities;
 
 :root {
-  --card-width: 400px;
+  --card-width: 384px;
 }
 
 /* Critical styles for cards */
 .card {
-  @apply relative bg-gray-50 dark:bg-darkblue dark:text-white p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
+  @apply relative bg-gray-50 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
+}
+
+.dark .card {
+  @apply bg-white/5 text-[#E4E9F0] backdrop-blur-lg border border-white/20 rounded-2xl p-6;
 }
 
 .card:hover {
@@ -94,11 +98,11 @@
 
 
 .photo-wrapper {
-  /* Increased size with maintained 3:4 ratio and stronger shadow */
-  /* Slightly taller to give the card more vertical room */
-  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-white dark:bg-darkblue shadow-lg ml-2;
+  @apply w-20 h-20 rounded-lg overflow-hidden flex items-center justify-center bg-white shadow-lg ml-2;
+}
 
-
+.dark .photo-wrapper {
+  @apply w-20 h-20 rounded-lg overflow-hidden flex items-center justify-center bg-transparent border-2 border-[#1E2230];
 }
 
 html.no-scroll,
@@ -110,6 +114,14 @@ body.no-scroll {
 /* Wrapper for faculty cards with adjustable width */
 .card-wrapper {
   /* Stretch up to the configured width but shrink on small screens */
-  max-width: var(--card-width, 18rem);
+  max-width: var(--card-width, 24rem);
   width: 100%;
+}
+
+/* Dark mode global background */
+html.dark body {
+  background-color: #0A0F1E;
+  background-image: url('/assets/neon-pattern.svg');
+  background-size: cover;
+  background-position: center;
 }

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -29,5 +29,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-filters')],
 };


### PR DESCRIPTION
## Summary
- integrate dark mode plugin and global background
- add reusable `DarkModeToggle` component
- tweak search bar and faculty card styles for glass look
- fix dark mode rate button sizing

## Testing
- `npm install`
- `npm run build` *(fails: fetch to Supabase blocked but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684d328c651c832f9b33222a733c2444