### PR TITLE
Add dark mode glassmorphic styling

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -43,9 +43,9 @@ const correctionCount =
       <div class="flex flex-col flex-1 h-40 dark:h-auto overflow-hidden">
  
 
-        <h3 class="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">{faculty.name || 'Unknown'}</h3>
+        <h3 class="text-2xl font-medium clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0]">{faculty.name || 'Unknown'}</h3>
         {specialization && (
-          <p class="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">
+          <p class="italic leading-snug mt-1 overflow-hidden flex-grow clamp-four-lines font-segoe text-gray-400 dark:text-[#CDD2E0]">
             {specialization}
           </p>
         )}

--- a/src/components/RateFaculty.tsx
+++ b/src/components/RateFaculty.tsx
@@ -52,7 +52,7 @@ export default function RateFaculty() {
         type="button"
         onClick={() => setOpen(true)}
  
-        className={`absolute bottom-2 left-2 px-2 py-0.5 rounded text-sm ${
+        className={`absolute bottom-2 left-2 rounded-full text-sm w-full h-12 ${
           isDark
             ? 'border border-[#00FFD8] text-[#00FFD8] hover:bg-white/10'
             : ratedAverage === null

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -94,9 +94,9 @@ export default function SearchBar() {
                 />
               </div>
               <div className="flex flex-col flex-1 h-40 overflow-hidden">
-                <h3 className="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">{item.name}</h3>
+                <h3 className="text-2xl font-medium clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0]">{item.name}</h3>
                 {item.specialization && (
-                  <p className="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">
+                  <p className="italic leading-snug mt-1 overflow-hidden flex-grow clamp-four-lines font-segoe text-gray-400 dark:text-[#CDD2E0]">
                     {item.specialization}
                   </p>
                 )}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -19,15 +19,8 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <link rel="preload" as="image" href="https://placehold.co/300x400?text=Faculty+4" />
   <script type="module" src="/viewTransitions.js"></script>
   <script type="module" src="/ratingSlider.js"></script>
-  <script>
-    const stored = localStorage.getItem('theme');
-    const prefers = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    if (stored === 'dark' || (!stored && prefers)) {
-      document.documentElement.classList.add('dark');
-    }
-  </script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:to-darkpurple text-gray-900 dark:text-gray-100">
+<body class="min-h-screen text-gray-900 dark:text-gray-100">
 
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
     <div class="w-full flex justify-center items-center">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,12 +8,11 @@
 
 /* Critical styles for cards */
 .card {
-  @apply relative bg-gray-50 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
+  @apply relative bg-white/5 backdrop-blur-lg border border-white/20 rounded-2xl p-6 shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
-.dark .card { 
-  @apply bg-white/5 text-[#E4E9F0] backdrop-blur-lg border border-white/20 rounded-2xl p-6;
- 
+.dark .card {
+  @apply bg-white/5 text-[#E4E9F0] border-white/20;
 }
 
 .card:hover {
@@ -99,15 +98,11 @@
 
 
 .photo-wrapper {
-  /* Increased size with maintained 3:4 ratio and stronger shadow */
-  /* Slightly taller to give the card more vertical room */
-  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-white shadow-lg ml-2;
+  @apply w-20 h-20 rounded-lg overflow-hidden flex items-center justify-center bg-white shadow-lg ml-2;
 }
- 
 
 .dark .photo-wrapper {
-  @apply w-28 h-40 rounded-lg overflow-hidden flex items-center justify-center bg-transparent border-2 border-[#1E2230];
- 
+  @apply w-20 h-20 rounded-lg overflow-hidden flex items-center justify-center bg-transparent border-2 border-[#1E2230];
 }
 
 html.no-scroll,


### PR DESCRIPTION
## Summary
- revamp card styles for glassmorphic look
- tweak image wrapper sizing
- adjust faculty name and specialization text
- update rate button styling
- clean up Base layout background and script

## Testing
- `npm install`
- `npm run build` *(fails: fetch to supabase blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684d4ccdf080832fa18381ccdebbf22d