### PR TITLE
Fix dark mode rating colors

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -52,12 +52,18 @@ function StarRow({ label, value, count }: { label: string; value: number; count?
 }
 
 function getTextColor(rating: number) {
-  if (rating === 5) return 'text-violet-600';
-  if (rating > 4) return 'text-green-600';
-  if (rating > 3.5) return 'text-green-500';
-  if (rating >= 3) return 'text-yellow-400';
-  if (rating >= 2) return 'text-red-500';
-  return 'text-red-700';
+  if (rating === 5) return 'text-violet-600 dark:text-[#00FFD8]';
+  if (rating > 4) return 'text-green-600 dark:text-[#00FFD8]';
+  if (rating > 3.5) return 'text-green-500 dark:text-[#00FFD8]';
+  if (rating >= 3) return 'text-yellow-400 dark:text-yellow-400';
+  if (rating >= 2) return 'text-red-500 dark:text-[#FF00C8]';
+  return 'text-red-700 dark:text-[#FF00C8]';
+}
+
+function getBoxDarkClasses(rating: number) {
+  if (rating > 4) return 'dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]';
+  if (rating >= 3) return 'dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]';
+  return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]';
 }
 
 export default function FacultyRatings({ teaching, attendance, correction, tCount, aCount, cCount }: Props) {
@@ -86,11 +92,11 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]">
+            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
               <RatingWidget rating={teaching} />
- 
-              <span className="text-sm text-gray-500 dark:text-[#FF00C8] font-segoe">Teaching</span>
- 
+
+              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
+              
             </div>
             {typeof tCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
@@ -103,11 +109,11 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]">
+            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>  
               <RatingWidget rating={attendance} />
- 
-              <span className="text-sm text-gray-500 dark:text-[#00FFD8] font-segoe">Attendance</span>
- 
+
+              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
+              
             </div>
             {typeof aCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
@@ -120,11 +126,11 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className="px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]">
+            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}> 
               <RatingWidget rating={correction} />
- 
-              <span className="text-sm text-gray-500 dark:text-[#FFD500] font-segoe">Correction</span>
- 
+
+              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
+              
             </div>
             {typeof cCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -6,7 +6,7 @@ interface Props {
   disabled?: boolean;
 }
 
-const getColor = (rating: number) => {
+const getLightColor = (rating: number) => {
   if (rating === 5) return 'bg-violet-600 text-white ring-2 ring-violet-300 animate-pulse';
   if (rating > 4) return 'bg-green-600 text-white';
   if (rating > 3.5) return 'bg-green-500 text-white';
@@ -15,9 +15,15 @@ const getColor = (rating: number) => {
   return 'bg-red-700 text-white';
 };
 
+const getDarkTextColor = (rating: number) => {
+  if (rating > 4) return 'dark:text-[#00FFD8]';
+  if (rating >= 3) return 'dark:text-yellow-400';
+  return 'dark:text-[#FF00C8]';
+};
+
 const RatingWidget: FC<Props> = ({ rating }) => {
   const value = typeof rating === 'number' ? rating : 0;
-  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getColor(value)}`;
+  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getLightColor(value)} dark:bg-transparent dark:ring-0 ${getDarkTextColor(value)}`;
   return (
     <div aria-label={`Rating ${value}`} className={classes}>
       {value.toFixed(1)}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -27,7 +27,7 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
     }
   </script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:to-darkpurple text-gray-900 dark:text-gray-100">
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:via-darkblue dark:to-black text-gray-900 dark:text-gray-100">
 
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
     <div class="w-full flex justify-center items-center">


### PR DESCRIPTION
## Summary
- tweak gradient colors for dark mode background
- remove colored background from rating numbers in dark theme
- compute faculty rating box colors dynamically in dark mode

## Testing
- `npm install`
- `npm run build` *(fails to fetch some resources but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684d55f77d8c832f8b273953922cc330