### PR TITLE
Enhance dark mode rating visuals

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -61,9 +61,9 @@ function getTextColor(rating: number) {
 }
 
 function getBoxDarkClasses(rating: number) {
-  if (rating > 4) return 'dark:border-[#00FFD8] dark:text-[#00FFD8] dark:hover:bg-[#00FFD8]20 dark:hover:drop-shadow-[0_0_10px_#00FFD8]';
-  if (rating >= 3) return 'dark:border-[#FFD500] dark:text-[#FFD500] dark:hover:bg-[#FFD500]20 dark:hover:drop-shadow-[0_0_10px_#FFD500]';
-  return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:hover:bg-[#FF00C8]20 dark:hover:drop-shadow-[0_0_10px_#FF00C8]';
+  if (rating > 4) return 'dark:border-[#00FFD8] dark:text-[#00FFD8] dark:bg-[#00FFD8]20 dark:drop-shadow-[0_0_10px_#00FFD8]';
+  if (rating >= 3) return 'dark:border-[#FFD500] dark:text-[#FFD500] dark:bg-[#FFD500]20 dark:drop-shadow-[0_0_10px_#FFD500]';
+  return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:bg-[#FF00C8]20 dark:drop-shadow-[0_0_10px_#FF00C8]';
 }
 
 export default function FacultyRatings({ teaching, attendance, correction, tCount, aCount, cCount }: Props) {

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -23,7 +23,7 @@ const getDarkTextColor = (rating: number) => {
 
 const RatingWidget: FC<Props> = ({ rating }) => {
   const value = typeof rating === 'number' ? rating : 0;
-  const classes = `px-2 py-1 rounded-lg font-bold text-sm ${getLightColor(value)} dark:bg-transparent dark:ring-0 ${getDarkTextColor(value)}`;
+  const classes = `px-2 py-1 rounded-lg font-bold text-lg ${getLightColor(value)} dark:bg-transparent dark:ring-0 ${getDarkTextColor(value)}`;
   return (
     <div aria-label={`Rating ${value}`} className={classes}>
       {value.toFixed(1)}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -11,9 +11,19 @@
   @apply relative bg-gray-50 p-4 rounded-lg shadow-md transition-shadow transition-transform transform animate-fade;
 }
 
-.dark .card { 
-  @apply bg-white/5 text-[#E4E9F0] backdrop-blur-lg border border-white/20 rounded-2xl p-6;
- 
+.dark .card {
+  @apply bg-white/5 text-[#E4E9F0] backdrop-blur-lg rounded-2xl p-6 border-2 border-transparent relative;
+  background-image: linear-gradient(#0A0F1E,#0A0F1E), linear-gradient(90deg,#FF00C8,#8000FF,#1E90FF,#FFFFFF);
+  background-origin: border-box;
+  background-clip: padding-box,border-box;
+  background-size: 200% 200%;
+  animation: borderMove 6s linear infinite;
+}
+
+@keyframes borderMove {
+  0% {background-position: 0% 50%;}
+  50% {background-position: 100% 50%;}
+  100% {background-position: 0% 50%;}
 }
 
 .card:hover {


### PR DESCRIPTION
## Summary
- make rating values larger
- keep rating boxes glowing in dark mode
- animate gradient borders on faculty cards

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d5884b5e8832f994d28febbd1ada7