### PR TITLE
Implement glassmorphism and darker background

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -92,7 +92,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
+            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
               <RatingWidget rating={teaching} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
@@ -109,7 +109,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>  
+            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
               <RatingWidget rating={attendance} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
@@ -126,7 +126,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-2 md:py-1 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}> 
+            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
               <RatingWidget rating={correction} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -39,6 +39,6 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
     <SearchBar client:load />
     
   </header>
-  <main class="container mx-auto p-4 md:p-8"><slot /></main>
+  <main class="relative container mx-auto p-4 md:p-8 overflow-hidden"><slot /></main>
 </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,6 +10,11 @@ const faculty = await fetchLists();
 const list = faculty;
 ---
 <Base>
+  <div class="animated-shapes" aria-hidden="true">
+    <div class="shape shape-one"></div>
+    <div class="shape shape-two"></div>
+    <div class="shape shape-three"></div>
+  </div>
   <DetailedToggle client:load />
   <SearchBar slot="search" client:load />
   <!-- Wrap cards with fixed width using flex -->

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -12,7 +12,7 @@
 }
 
 .dark .card {
-  @apply bg-white/5 text-[#E4E9F0] backdrop-blur-lg rounded-2xl p-6 border-2 border-transparent relative;
+  @apply bg-white/10 text-[#E4E9F0] backdrop-blur-xl rounded-2xl p-6 border border-white/20 shadow-lg relative;
   background-image: linear-gradient(#0A0F1E,#0A0F1E), linear-gradient(90deg,#FF00C8,#8000FF,#1E90FF,#FFFFFF);
   background-origin: border-box;
   background-clip: padding-box,border-box;
@@ -135,8 +135,60 @@ body.no-scroll {
 
 /* Dark mode global background */
 html.dark body {
-  background-color: #0A0F1E;
-  background-image: url('/assets/neon-pattern.svg');
+  background-color: #000;
+  background-image: radial-gradient(circle at 20% 30%, #8000ff40, transparent 60%), radial-gradient(circle at 80% 70%, #ff00c840, transparent 60%), linear-gradient(#0a0116, #000);
+  background-attachment: fixed;
   background-size: cover;
   background-position: center;
+}
+
+.animated-shapes {
+  @apply absolute inset-0 pointer-events-none overflow-hidden;
+}
+
+.shape {
+  @apply absolute rounded-full opacity-30 blur-3xl mix-blend-screen;
+}
+
+.shape-one {
+  width: 20rem;
+  height: 20rem;
+  background: radial-gradient(circle, #ff00c8, transparent 70%);
+  top: -5rem;
+  left: -5rem;
+  animation: move-one 12s ease-in-out infinite alternate;
+}
+
+.shape-two {
+  width: 24rem;
+  height: 24rem;
+  background: radial-gradient(circle, #00ffd8, transparent 70%);
+  bottom: -8rem;
+  right: -8rem;
+  animation: move-two 15s ease-in-out infinite alternate;
+}
+
+.shape-three {
+  width: 16rem;
+  height: 16rem;
+  background: radial-gradient(circle, #8000ff, transparent 70%);
+  top: 40%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  animation: move-three 18s ease-in-out infinite alternate;
+}
+
+@keyframes move-one {
+  from { transform: translate(0, 0) rotate(0deg); }
+  to { transform: translate(40px, -40px) rotate(45deg); }
+}
+
+@keyframes move-two {
+  from { transform: translate(0, 0) rotate(0deg); }
+  to { transform: translate(-30px, 30px) rotate(-30deg); }
+}
+
+@keyframes move-three {
+  from { transform: translate(-50%, -50%) scale(1); }
+  to { transform: translate(-60%, -40%) scale(1.2); }
 }


### PR DESCRIPTION
## Summary
- shrink rating boxes in `FacultyRatings`
- apply glassmorphism styling to faculty cards
- darken background and add animated geometric shapes
- place animated shapes on home page
- ensure main container is positioned for absolute shapes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d5ac0f97c832fa25abf55dd43a9d6