### PR TITLE
Adjust rating box height in dark theme

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -92,7 +92,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
         <div className="grid grid-cols-3 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
+            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
               <RatingWidget rating={teaching} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
@@ -109,7 +109,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
+            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
               <RatingWidget rating={attendance} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
@@ -126,7 +126,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
+            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
               <RatingWidget rating={correction} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>

--- a/src/components/RatingWidget.tsx
+++ b/src/components/RatingWidget.tsx
@@ -23,7 +23,7 @@ const getDarkTextColor = (rating: number) => {
 
 const RatingWidget: FC<Props> = ({ rating }) => {
   const value = typeof rating === 'number' ? rating : 0;
-  const classes = `px-2 py-1 rounded-lg font-bold text-lg ${getLightColor(value)} dark:bg-transparent dark:ring-0 ${getDarkTextColor(value)}`;
+  const classes = `px-2 py-1 dark:py-0.5 rounded-lg font-bold text-lg ${getLightColor(value)} dark:bg-transparent dark:ring-0 ${getDarkTextColor(value)}`;
   return (
     <div aria-label={`Rating ${value}`} className={classes}>
       {value.toFixed(1)}


### PR DESCRIPTION
## Summary
- shrink the padding for rating widgets when dark mode is enabled

## Testing
- `npm run build` *(fails: fetch errors)*

------
https://chatgpt.com/codex/tasks/task_e_684d5bfe2128832fb4721bd63a57692a