### PR TITLE
Improve dark mode rate button

### DIFF
--- a/src/components/RateFaculty.tsx
+++ b/src/components/RateFaculty.tsx
@@ -54,7 +54,8 @@ export default function RateFaculty() {
  
         className={`absolute bottom-2 left-2 px-2 py-0.5 rounded text-sm ${
           isDark
-            ? 'border border-[#00FFD8] text-[#00FFD8] hover:bg-white/10'
+            ?
+              'border border-[#FFD500] text-[#FFD500] hover:bg-[#FFD500]20 drop-shadow-[0_0_10px_#FFD500]'
             : ratedAverage === null
               ? 'bg-gray-400 text-white hover:bg-gray-500'
               : 'bg-yellow-300 text-gray-900'


### PR DESCRIPTION
## Summary
- tweak `RateFaculty` dark mode to use yellow accent and glow

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d5efa0adc832f81fb61e57af42e18