### PR TITLE
Fix dark search results

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -79,8 +79,11 @@ export default function SearchBar() {
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-x-4 gap-y-8 justify-items-center">
         {results.map((item) => (
 
-          <article key={item.name} className="card pb-32 card-wrapper">
-            <div className="flex items-start gap-4 mb-2 h-40">
+          <article
+            key={item.name}
+            className="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6"
+          >
+            <div className="flex items-start gap-4 mb-2 h-40 dark:h-auto">
               <div className="photo-wrapper">
                 <img
                   src={item.photo_url || 'https://placehold.co/300x400?text=No+Photo'}
@@ -93,7 +96,7 @@ export default function SearchBar() {
                   className="faculty-photo"
                 />
               </div>
-              <div className="flex flex-col flex-1 h-40 overflow-hidden">
+              <div className="flex flex-col flex-1 h-40 dark:h-auto overflow-hidden">
                 <h3 className="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">{item.name}</h3>
                 {item.specialization && (
                   <p className="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">


### PR DESCRIPTION
## Summary
- dark mode classes for search results

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d67a84b20832f8f4399df5d710b02