### PR TITLE
Add wishlist functionality with profile icon

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -63,5 +63,5 @@ const correctionCount =
       />
     </div>
     <RateFaculty client:visible />
-    <HeartButton client:visible />
+    <HeartButton faculty={faculty} client:visible />
 </article>

--- a/src/components/FacultyCardReact.tsx
+++ b/src/components/FacultyCardReact.tsx
@@ -1,0 +1,84 @@
+import FacultyRatings from './FacultyRatings.tsx';
+import RateFaculty from './RateFaculty.tsx';
+import HeartButton from './HeartButton.tsx';
+import type { Faculty } from '../hooks/useWishlist';
+
+export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
+  const photoUrl = faculty.photo_url || (faculty as any).photo;
+  const specializationRaw =
+    faculty.specialization ||
+    (faculty as any).specialisation ||
+    (faculty as any).specializations ||
+    (faculty as any).dept ||
+    (faculty as any).department;
+
+  let specialization = specializationRaw as string | undefined;
+  if (specializationRaw) {
+    const words = (specializationRaw as string).split(/\s+/);
+    if (words.length > 12) {
+      specialization = words.slice(0, 12).join(' ') + '...';
+    }
+  }
+
+  const teachingCount =
+    (faculty as any).num_teaching_ratings ??
+    (faculty as any).numTeachingRatings ??
+    (faculty as any).ratingsCount ??
+    (faculty as any).total_ratings ??
+    null;
+  const attendanceCount =
+    (faculty as any).num_attendance_ratings ??
+    (faculty as any).numAttendanceRatings ??
+    (faculty as any).ratingsCount ??
+    (faculty as any).total_ratings ??
+    null;
+  const correctionCount =
+    (faculty as any).num_correction_ratings ??
+    (faculty as any).numCorrectionRatings ??
+    (faculty as any).ratingsCount ??
+    (faculty as any).total_ratings ??
+    null;
+
+  return (
+    <article className="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6">
+      <div className="flex items-start gap-4 mb-2 h-40 dark:h-auto">
+        <div className="photo-wrapper">
+          <img
+            src={photoUrl}
+            alt={`Photo of ${faculty.name || 'Unknown'}`}
+            loading="lazy"
+            onError={(e) => {
+              const target = e.currentTarget as HTMLImageElement;
+              target.src = 'https://placehold.co/300x400?text=No+Photo';
+              target.onerror = null;
+            }}
+            className="faculty-photo"
+          />
+        </div>
+        <div className="flex flex-col flex-1 h-40 dark:h-auto overflow-hidden">
+          <h3 className="text-lg font-bold mb-1 clamp-two-lines faculty-name font-poppins dark:text-[#E4E9F0] dark:text-2xl dark:font-medium">
+            {faculty.name || 'Unknown'}
+          </h3>
+          {specialization && (
+            <p className="text-sm italic text-gray-400 leading-snug overflow-hidden flex-grow clamp-four-lines font-segoe dark:text-[#CDD2E0] dark:font-normal mt-1">
+              {specialization}
+            </p>
+          )}
+        </div>
+      </div>
+      <div className="mb-4">
+        <FacultyRatings
+          teaching={(faculty as any).teaching_rating ?? (faculty as any).teachingRating}
+          attendance={(faculty as any).attendance_rating ?? (faculty as any).attendanceRating}
+          correction={(faculty as any).correction_rating ?? (faculty as any).correctionRating}
+          tCount={teachingCount}
+          aCount={attendanceCount}
+          cCount={correctionCount}
+          client:visible
+        />
+      </div>
+      <RateFaculty client:visible />
+      <HeartButton faculty={faculty} client:visible />
+    </article>
+  );
+}

--- a/src/components/HeartButton.tsx
+++ b/src/components/HeartButton.tsx
@@ -1,22 +1,27 @@
 import { useState } from 'react';
+import useWishlist from '../hooks/useWishlist';
+import type { Faculty } from '../hooks/useWishlist';
+interface Props {
+  faculty: Faculty;
+}
 
-export default function HeartButton() {
-  const [liked, setLiked] = useState(false);
+export default function HeartButton({ faculty }: Props) {
+  const { wishlist, toggle } = useWishlist();
   const [animate, setAnimate] = useState(false);
+  const liked = wishlist.some((f) => f.id === faculty.id);
 
-  const toggle = () => {
-    setLiked(!liked);
+  const handle = () => {
+    toggle(faculty);
     setAnimate(true);
   };
 
   return (
     <svg
-      onClick={toggle}
+      onClick={handle}
       onAnimationEnd={() => setAnimate(false)}
  
       className={`w-6 h-6 cursor-pointer absolute bottom-2 right-2 transition-colors ${
- 
-        liked ? 'text-red-500' : 'text-gray-400'
+        liked ? 'text-red-500' : 'text-gray-400 dark:text-gray-500'
       } ${animate ? 'animate-pop' : ''}`}
       viewBox="0 0 24 24"
       fill={liked ? 'currentColor' : 'none'}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -116,7 +116,7 @@ export default function SearchBar() {
               />
             </div>
             <RateFaculty />
-            <HeartButton />
+            <HeartButton faculty={item} />
           </article>
 
         ))}

--- a/src/components/WishlistIcon.tsx
+++ b/src/components/WishlistIcon.tsx
@@ -1,0 +1,25 @@
+import useWishlist from '../hooks/useWishlist';
+
+export default function WishlistIcon() {
+  const { wishlist } = useWishlist();
+  return (
+    <a href="/wishlist" aria-label="Wishlist" className="relative">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        className="w-6 h-6 text-gray-700 dark:text-pink-400"
+      >
+        <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+      </svg>
+      {wishlist.length > 0 && (
+        <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs rounded-full px-1">
+          {wishlist.length}
+        </span>
+      )}
+    </a>
+  );
+}

--- a/src/components/WishlistView.tsx
+++ b/src/components/WishlistView.tsx
@@ -1,0 +1,20 @@
+import useWishlist from '../hooks/useWishlist';
+import FacultyCardReact from './FacultyCardReact.tsx';
+
+export default function WishlistView() {
+  const { wishlist } = useWishlist();
+
+  if (wishlist.length === 0) {
+    return <p className="text-center mt-8">No wishlisted faculty.</p>;
+  }
+
+  return (
+    <div className="flex flex-wrap justify-center gap-x-4 gap-y-8">
+      {wishlist.map((f) => (
+        <div className="card-wrapper" key={f.id || f.name}>
+          <FacultyCardReact faculty={f} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+
+export interface Faculty {
+  id?: string;
+  name?: string;
+  [key: string]: any;
+}
+
+export default function useWishlist() {
+  const [wishlist, setWishlist] = useState<Faculty[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('wishlist');
+    if (stored) {
+      try {
+        setWishlist(JSON.parse(stored));
+      } catch {}
+    }
+    const handler = (e: Event) => {
+      const data = (e as CustomEvent<Faculty[]>).detail;
+      setWishlist(data);
+    };
+    window.addEventListener('wishlist-change', handler);
+    return () => window.removeEventListener('wishlist-change', handler);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('wishlist', JSON.stringify(wishlist));
+  }, [wishlist]);
+
+  function toggle(faculty: Faculty) {
+    setWishlist((curr) => {
+      const exists = curr.some((f) => f.id === faculty.id);
+      const updated = exists
+        ? curr.filter((f) => f.id !== faculty.id)
+        : [...curr, faculty];
+      window.dispatchEvent(
+        new CustomEvent('wishlist-change', { detail: updated })
+      );
+      return updated;
+    });
+  }
+
+  return { wishlist, toggle };
+}

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import SearchBar from '../components/SearchBar.tsx';
 import DarkModeToggle from '../components/DarkModeToggle.tsx';
+import WishlistIcon from '../components/WishlistIcon.tsx';
 const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props;
 ---
 <!DOCTYPE html>
@@ -29,12 +30,16 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
 </head>
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:via-darkblue dark:to-black text-gray-900 dark:text-gray-100 animated-bg">
 
-  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2">
+  <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2 bg-transparent">
     <div class="w-full flex justify-center items-center">
- 
+
       <h1 class="text-4xl font-semibold dark:text-[#00FFD8]">{headerTitle}</h1>
- 
-      <DarkModeToggle client:load class="absolute right-4" />
+
+      <div class="absolute right-4 flex items-center gap-4">
+        <WishlistIcon client:load />
+        <img src="https://placehold.co/40x40" alt="Profile" class="w-10 h-10 rounded-full border-2 border-gray-300 dark:border-gray-600" />
+        <DarkModeToggle client:load />
+      </div>
     </div>
     <SearchBar client:load />
     

--- a/src/pages/wishlist.astro
+++ b/src/pages/wishlist.astro
@@ -1,0 +1,7 @@
+---
+import Base from '../layouts/Base.astro';
+import WishlistView from '../components/WishlistView.tsx';
+---
+<Base title="Wishlist" headerTitle="Wishlist">
+  <WishlistView client:load />
+</Base>


### PR DESCRIPTION
## Summary
- add wishlist hook to manage faculty list
- create wishlist card and view components
- add heart wishlist icon and profile image in header
- update heart buttons to store favorites
- add wishlist page listing saved faculty

## Testing
- `npm install`
- `npm run build` *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a6a7388832fb44444c73e3a8a98