### PR TITLE
Improve dark mode performance

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -9,7 +9,7 @@ const faculty = await fetchLists();
 const list = faculty;
 ---
 <Base>
-  <div class="animated-shapes" aria-hidden="true">
+  <div class="animated-shapes dark:hidden" aria-hidden="true">
     <div class="shape shape-one"></div>
     <div class="shape shape-two"></div>
     <div class="shape shape-three"></div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,7 +134,6 @@ body.no-scroll {
 html.dark body {
   background-color: #000;
   background-image: radial-gradient(circle at 20% 30%, #8000ff40, transparent 60%), radial-gradient(circle at 80% 70%, #ff00c840, transparent 60%), linear-gradient(#0a0116, #000);
-  background-attachment: fixed;
   background-position: center;
 }
 


### PR DESCRIPTION
## Summary
- hide animated background shapes in dark mode
- remove `background-attachment: fixed` from dark mode styles

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d713d6610832fab028a2349e6adff