### PR TITLE
Fix header layout and light mode toggle

### DIFF
--- a/src/components/DarkModeToggle.astro
+++ b/src/components/DarkModeToggle.astro
@@ -2,7 +2,10 @@
 const { className = '' } = Astro.props;
 ---
 <button id="dark-mode-toggle" class={`p-2 rounded-md ${className} bg-gray-200 dark:bg-gray-800`} aria-label="Toggle dark mode">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-gray-700 dark:text-[#00FFD8]">
+  <svg viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-gray-700 dark:hidden">
+    <circle cx="12" cy="12" r="6" />
+  </svg>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6 text-[#00FFD8] hidden dark:block">
     <path d="M21 12.79A9 9 0 0111.21 3 7 7 0 1012 21a9 9 0 009-8.21z" />
   </svg>
 </button>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -25,16 +25,14 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
 <body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:via-darkblue dark:to-black text-gray-900 dark:text-gray-100">
 
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2 bg-transparent">
-    <div class="w-full flex justify-center items-center">
-
-      <h1 class="text-4xl font-semibold dark:text-[#00FFD8]">{headerTitle}</h1>
-
-      <div class="absolute right-4 flex items-center gap-4">
-        <WishlistIcon />
-        <img src="https://placehold.co/40x40" alt="Profile" class="w-10 h-10 rounded-full border-2 border-gray-300 dark:border-gray-600" />
+    <div class="w-full flex items-center justify-between">
+      <div class="flex items-center gap-4">
         <DarkModeToggle />
+        <WishlistIcon />
       </div>
+      <img src="https://placehold.co/40x40" alt="Profile" class="w-10 h-10 rounded-full border-2 border-gray-300 dark:border-gray-600" />
     </div>
+    <h1 class="text-4xl font-semibold dark:text-[#00FFD8] text-center">{headerTitle}</h1>
     <SearchBar client:idle />
     
   </header>


### PR DESCRIPTION
## Summary
- rearrange header so the wishlist and profile don't overlap the title
- update dark mode toggle so it shows a sun icon when in light mode

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d74a7f5f4832fac1a7737f929aa7e