### PR TITLE
Enable filtering without a search query

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -37,20 +37,19 @@ export default function SearchBar() {
   const [correctionFilter, setCorrectionFilter] = useState(0);
 
   useEffect(() => {
-    if (!query.trim()) {
-      setResults([]);
-      setAllResults([]);
-      return;
-    }
-
     const ctrl = { cancelled: false };
     setLoading(true);
     setError(null);
     const timer = setTimeout(async () => {
-      const { data, error } = await supabase
-        .from('lists')
-        .select('*')
-        .ilike('name', `%${query}%`);
+      let data, error;
+      if (query.trim()) {
+        ({ data, error } = await supabase
+          .from('lists')
+          .select('*')
+          .ilike('name', `%${query}%`));
+      } else {
+        ({ data, error } = await supabase.from('lists').select('*'));
+      }
       if (ctrl.cancelled) return;
       if (error) {
         setError(error.message);


### PR DESCRIPTION
## Summary
- update SearchBar to load all faculty when the search box is empty

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684d79a8b00c832fa43dae78c479e515