### PR TITLE
Add dashed separator after search results

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -354,6 +354,9 @@ export default function SearchBar() {
           </article>
         ))}
       </div>
+      {displayResults.length > 0 && (
+        <hr className="my-8 mx-auto w-1/2 border-t-2 border-dashed border-gray-400" />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- improve SearchBar UX by placing a dashed separator below filtered results

## Testing
- `npm run build` *(fails: fetch errors due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684d8fbc909c832fabb7f3867015154f