### PR TITLE
Improve sort functionality

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,9 +16,9 @@ const list = faculty;
   </div>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div class="flex flex-wrap justify-center gap-x-4 gap-y-8">
-    {paginate(list, page).map(f => (
-      <div class="card-wrapper">
+  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+    {paginate(list, page).map((f, i) => (
+      <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />
       </div>
     ))}

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -20,9 +20,9 @@ if (page < 1 || page > pages) {
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div class="flex flex-wrap justify-center gap-x-4 gap-y-8">
-    {paginate(faculty, page).map(f => (
-      <div class="card-wrapper">
+  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+    {paginate(faculty, page).map((f, i) => (
+      <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />
       </div>
     ))}


### PR DESCRIPTION
## Summary
- close filter and sort dropdowns when clicking elsewhere
- allow sort options to rearrange home cards
- mark home cards with data attributes for sorting

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d91c975ac832fa0f6fa8df9cac882