### PR TITLE
Fix card alignment and add filter clear option

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -338,6 +338,18 @@ export default function SearchBar() {
             >
               Apply
             </button>
+
+            <button
+              type="button"
+              onClick={() => {
+                setTeachingFilter(0);
+                setAttendanceFilter(0);
+                setCorrectionFilter(0);
+              }}
+              className="mt-2 w-full px-3 py-2 rounded-md bg-gray-200 text-gray-800 dark:bg-[#1E2230] dark:text-gray-100 hover:bg-gray-300 dark:hover:bg-[#374151]"
+            >
+              Clear filters
+            </button>
  
             </form>
             )}
@@ -396,7 +408,7 @@ export default function SearchBar() {
         )}
       {/* Display search results using same layout as the homepage */}
  
-      <div className="flex flex-wrap justify-center gap-x-4 gap-y-8">
+      <div className="flex flex-wrap justify-start gap-x-4 gap-y-8">
  
         {displayResults.map((item) => (
           <article

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const list = faculty;
   </div>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+  <div id="home-cards" class="flex flex-wrap justify-start gap-x-4 gap-y-8">
     {paginate(list, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -20,7 +20,7 @@ if (page < 1 || page > pages) {
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+  <div id="home-cards" class="flex flex-wrap justify-start gap-x-4 gap-y-8">
     {paginate(faculty, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />


### PR DESCRIPTION
## Summary
- ensure faculty grid starts from the left instead of being centered
- add "Clear filters" button to reset all rating filters

## Testing
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684d97a1d528832f859d7877911cabba