### PR TITLE
Fix card width so first column stays

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -354,7 +354,7 @@ export default function SearchBar() {
             {showSort && (
               <div
                 ref={sortRef}
-                className="absolute z-20 left-0 mt-2 w-56 p-4 bg-white border border-gray-300 rounded-lg shadow-lg dark:bg-[#0A0F1E] dark:border-gray-700"
+                className="absolute z-50 left-0 mt-2 w-56 p-4 bg-white border border-gray-300 rounded-lg shadow-lg dark:bg-[#0A0F1E] dark:border-gray-700"
               >
                 <label className="block text-sm font-semibold mb-1 dark:text-gray-200">Sort by</label>
                 <select
@@ -396,7 +396,7 @@ export default function SearchBar() {
         )}
       {/* Display search results using same layout as the homepage */}
  
-      <div className="flex flex-wrap justify-center gap-x-4 gap-y-8">
+      <div className="flex flex-wrap justify-start gap-x-4 gap-y-8">
  
         {displayResults.map((item) => (
           <article

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,7 @@ const list = faculty;
   </div>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+  <div id="home-cards" class="flex flex-wrap justify-start gap-x-4 gap-y-8">
     {paginate(list, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -20,7 +20,7 @@ if (page < 1 || page > pages) {
 <Base title={`Page ${page} - Faculty Ranker`}>
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8">
+  <div id="home-cards" class="flex flex-wrap justify-start gap-x-4 gap-y-8">
     {paginate(faculty, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,9 +124,10 @@ body.no-scroll {
 
 /* Wrapper for faculty cards with adjustable width */
 .card-wrapper {
-  /* Stretch up to the configured width but shrink on small screens */
-  max-width: var(--card-width, 24rem);
-  width: 100%;
+  /* Fixed width so cards always occupy the first column */
+  width: var(--card-width, 24rem);
+  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 /* Dark mode global background */


### PR DESCRIPTION
## Summary
- keep faculty card width fixed to avoid gap in first column

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684da694f628832fbbc77903498b0178