### PR TITLE
Center card rows again

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -354,7 +354,7 @@ export default function SearchBar() {
             {showSort && (
               <div
                 ref={sortRef}
-                className="absolute z-20 left-0 mt-2 w-56 p-4 bg-white border border-gray-300 rounded-lg shadow-lg dark:bg-[#0A0F1E] dark:border-gray-700"
+                className="absolute z-50 left-0 mt-2 w-56 p-4 bg-white border border-gray-300 rounded-lg shadow-lg dark:bg-[#0A0F1E] dark:border-gray-700"
               >
                 <label className="block text-sm font-semibold mb-1 dark:text-gray-200">Sort by</label>
                 <select

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -124,9 +124,10 @@ body.no-scroll {
 
 /* Wrapper for faculty cards with adjustable width */
 .card-wrapper {
-  /* Stretch up to the configured width but shrink on small screens */
-  max-width: var(--card-width, 24rem);
-  width: 100%;
+  /* Fixed width so cards always occupy the first column */
+  width: var(--card-width, 24rem);
+  max-width: 100%;
+  flex: 0 0 auto;
 }
 
 /* Dark mode global background */


### PR DESCRIPTION
## Summary
- center home cards again so layout remains centered while sort overlay sits on top

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684da694f628832fbbc77903498b0178