### PR TITLE
Set dark mode background to solid black

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -22,7 +22,7 @@ const { title = 'Faculty Ranker', headerTitle = 'Faculty Ranker' } = Astro.props
   <script type="module" src="/ratingSlider.js"></script>
   <script src="/darkMode.js" is:inline></script>
 </head>
-<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:from-darkpurple dark:via-darkblue dark:to-black text-gray-900 dark:text-gray-100">
+<body class="min-h-screen bg-gradient-to-br from-gray-50 to-gray-200 dark:bg-black dark:bg-none text-gray-900 dark:text-gray-100">
 
   <header class="relative p-4 mt-4 mb-2 flex flex-col items-center gap-2 bg-transparent">
     <div class="w-full flex items-center justify-between">

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -134,8 +134,7 @@ body.no-scroll {
 
 html.dark body {
   background-color: #000;
-  background-image: radial-gradient(circle at 20% 30%, #8000ff40, transparent 60%), radial-gradient(circle at 80% 70%, #ff00c840, transparent 60%), linear-gradient(#0a0116, #000);
-  background-position: center;
+  background-image: none;
 }
 
 .animated-bg {


### PR DESCRIPTION
## Summary
- use a solid black background in dark mode
- remove dark-mode gradient from global styles

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dabdd3ba0832f93d4e5982788223f