### PR TITLE
Remove dark mode rating glow

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -61,9 +61,9 @@ function getTextColor(rating: number) {
 }
 
 function getBoxDarkClasses(rating: number) {
-  if (rating > 4) return 'dark:border-[#00FFD8] dark:text-[#00FFD8] dark:bg-[#00FFD8]20 dark:drop-shadow-[0_0_10px_#00FFD8]';
-  if (rating >= 3) return 'dark:border-[#FFD500] dark:text-[#FFD500] dark:bg-[#FFD500]20 dark:drop-shadow-[0_0_10px_#FFD500]';
-  return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:bg-[#FF00C8]20 dark:drop-shadow-[0_0_10px_#FF00C8]';
+  if (rating > 4) return 'dark:border-[#00FFD8] dark:text-[#00FFD8] dark:bg-[#00FFD8]20';
+  if (rating >= 3) return 'dark:border-[#FFD500] dark:text-[#FFD500] dark:bg-[#FFD500]20';
+  return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:bg-[#FF00C8]20';
 }
 
 export default function FacultyRatings({ teaching, attendance, correction, tCount, aCount, cCount }: Props) {

--- a/src/components/RateFaculty.tsx
+++ b/src/components/RateFaculty.tsx
@@ -55,7 +55,7 @@ export default function RateFaculty() {
         className={`absolute bottom-2 left-2 px-2 py-0.5 rounded text-sm ${
           isDark
             ?
-              'border border-[#FFD500] text-[#FFD500] hover:bg-[#FFD500]20 drop-shadow-[0_0_10px_#FFD500]'
+              'border border-[#FFD500] text-[#FFD500] hover:bg-[#FFD500]20'
             : ratedAverage === null
               ? 'bg-gray-400 text-white hover:bg-gray-500'
               : 'bg-yellow-300 text-gray-900'


### PR DESCRIPTION
## Summary
- remove drop shadows from rating boxes
- stop using drop shadow for rate button in dark mode

## Testing
- `npm install`
- `npm run build` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_684dad444f24832fb97697d428e0182c