### PR TITLE
Fix first card alignment

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,14 +17,11 @@ const list = faculty;
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
  
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8 w-fit mx-auto">
- 
-    {paginate(list, page).map((f, i) => (
+  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8 w-fit mx-auto">{paginate(list, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />
       </div>
-    ))}
-  </div>
+    ))}</div>
   <nav class="mt-4 flex justify-center gap-2">
     <a href="/page/2" class="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800">Next &rarr;</a>
   </nav>

--- a/src/pages/page/[n].astro
+++ b/src/pages/page/[n].astro
@@ -21,14 +21,11 @@ if (page < 1 || page > pages) {
   <DetailedToggle />
   <!-- Wrap cards with fixed width using flex -->
  
-  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8 w-fit mx-auto">
- 
-    {paginate(faculty, page).map((f, i) => (
+  <div id="home-cards" class="flex flex-wrap justify-center gap-x-4 gap-y-8 w-fit mx-auto">{paginate(faculty, page).map((f, i) => (
       <div class="card-wrapper" data-index={i} data-name={f.name || ''} data-teach={f.teaching_rating ?? 0} data-attend={f.attendance_rating ?? 0} data-correct={f.correction_rating ?? 0} data-total={f.total_ratings ?? 0}>
         <FacultyCard faculty={f} />
       </div>
-    ))}
-  </div>
+    ))}</div>
   <nav class="mt-4 flex justify-center gap-2">
     {page > 1 && (
       <a href={`/page/${page-1}`} class="px-4 py-2 rounded-lg bg-black text-white hover:bg-gray-800">&larr; Prev</a>


### PR DESCRIPTION
## Summary
- remove leading whitespace in card lists so first row renders properly

## Testing
- `npm run build` *(fails: fetch to supabase blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684daf013a38832faa3e7f92a5820700