### PR TITLE
Add quiz rating box

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -56,6 +56,7 @@ const correctionCount =
         teaching={faculty.teaching_rating ?? faculty.teachingRating}
         attendance={faculty.attendance_rating ?? faculty.attendanceRating}
         correction={faculty.correction_rating ?? faculty.correctionRating}
+        quiz={faculty.quiz_rating ?? faculty.quizRating}
         tCount={teachingCount}
         aCount={attendanceCount}
         cCount={correctionCount}

--- a/src/components/FacultyCardReact.tsx
+++ b/src/components/FacultyCardReact.tsx
@@ -71,6 +71,7 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
           teaching={(faculty as any).teaching_rating ?? (faculty as any).teachingRating}
           attendance={(faculty as any).attendance_rating ?? (faculty as any).attendanceRating}
           correction={(faculty as any).correction_rating ?? (faculty as any).correctionRating}
+          quiz={(faculty as any).quiz_rating ?? (faculty as any).quizRating}
           tCount={teachingCount}
           aCount={attendanceCount}
           cCount={correctionCount}

--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -5,6 +5,7 @@ type Props = {
   teaching: number | null | undefined;
   attendance: number | null | undefined;
   correction: number | null | undefined;
+  quiz?: number | null | undefined;
   tCount?: number | null | undefined;
   aCount?: number | null | undefined;
   cCount?: number | null | undefined;
@@ -66,7 +67,7 @@ function getBoxDarkClasses(rating: number) {
   return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:bg-[#FF00C8]20';
 }
 
-export default function FacultyRatings({ teaching, attendance, correction, tCount, aCount, cCount }: Props) {
+export default function FacultyRatings({ teaching, attendance, correction, quiz, tCount, aCount, cCount }: Props) {
   const [detailed, setDetailed] = useState<boolean>(
     typeof window !== 'undefined' && (window as any).showDetailedRatings === true
   );
@@ -130,7 +131,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
               <RatingWidget rating={correction} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
-              
+
             </div>
             {typeof cCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
@@ -140,6 +141,15 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
                 {cCount}
               </span>
             )}
+          </div>
+
+          <div className="flex flex-col items-center gap-1">
+            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
+              <RatingWidget rating={quiz} />
+
+              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
+
+            </div>
           </div>
         </div>
       )}

--- a/src/components/FixedCardLayout.tsx
+++ b/src/components/FixedCardLayout.tsx
@@ -11,7 +11,7 @@ export function FacultyCardExample() {
       />
       <h3 className="text-lg font-semibold font-poppins">Prof. Jane Doe</h3>
       <p className="text-sm italic text-gray-500">Computer Science</p>
-      <FacultyRatings teaching={4.5} attendance={4.2} correction={4.7} />
+      <FacultyRatings teaching={4.5} attendance={4.2} correction={4.7} quiz={4.0} />
     </div>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -277,6 +277,7 @@ export default function SearchBar() {
                 teaching={item.teaching_rating ?? 0}
                 attendance={item.attendance_rating ?? 0}
                 correction={item.correction_rating ?? 0}
+                quiz={item.quiz_rating ?? 0}
                 tCount={item.total_ratings ?? null}
                 aCount={item.total_ratings ?? null}
                 cCount={item.total_ratings ?? null}


### PR DESCRIPTION
## Summary
- allow FacultyRatings to handle a `quiz` rating
- show a new Quiz rating box as the only box on a second row
- pass quiz rating through card components and search results
- update example layout with sample quiz rating

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dbc91a8c4832fb2de52a645a855b5