### PR TITLE
Add quiz rating count

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -25,6 +25,8 @@ const attendanceCount =
   faculty.num_attendance_ratings ?? faculty.numAttendanceRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 const correctionCount =
   faculty.num_correction_ratings ?? faculty.numCorrectionRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
+const quizCount =
+  faculty.num_quiz_ratings ?? faculty.numQuizRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 
 ---
 <article class="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6">
@@ -56,9 +58,11 @@ const correctionCount =
         teaching={faculty.teaching_rating ?? faculty.teachingRating}
         attendance={faculty.attendance_rating ?? faculty.attendanceRating}
         correction={faculty.correction_rating ?? faculty.correctionRating}
+        quiz={faculty.quiz_rating ?? faculty.quizRating}
         tCount={teachingCount}
         aCount={attendanceCount}
         cCount={correctionCount}
+        qCount={quizCount}
         client:visible
       />
     </div>

--- a/src/components/FacultyCardReact.tsx
+++ b/src/components/FacultyCardReact.tsx
@@ -38,6 +38,12 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
     (faculty as any).ratingsCount ??
     (faculty as any).total_ratings ??
     null;
+  const quizCount =
+    (faculty as any).num_quiz_ratings ??
+    (faculty as any).numQuizRatings ??
+    (faculty as any).ratingsCount ??
+    (faculty as any).total_ratings ??
+    null;
 
   return (
     <article className="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6">
@@ -71,9 +77,11 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
           teaching={(faculty as any).teaching_rating ?? (faculty as any).teachingRating}
           attendance={(faculty as any).attendance_rating ?? (faculty as any).attendanceRating}
           correction={(faculty as any).correction_rating ?? (faculty as any).correctionRating}
+          quiz={(faculty as any).quiz_rating ?? (faculty as any).quizRating}
           tCount={teachingCount}
           aCount={attendanceCount}
           cCount={correctionCount}
+          qCount={quizCount}
           client:visible
         />
       </div>

--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -5,9 +5,11 @@ type Props = {
   teaching: number | null | undefined;
   attendance: number | null | undefined;
   correction: number | null | undefined;
+  quiz?: number | null | undefined;
   tCount?: number | null | undefined;
   aCount?: number | null | undefined;
   cCount?: number | null | undefined;
+  qCount?: number | null | undefined;
 };
 
 function Star({ filled }: { filled: boolean }) {
@@ -66,7 +68,7 @@ function getBoxDarkClasses(rating: number) {
   return 'dark:border-[#FF00C8] dark:text-[#FF00C8] dark:bg-[#FF00C8]20';
 }
 
-export default function FacultyRatings({ teaching, attendance, correction, tCount, aCount, cCount }: Props) {
+export default function FacultyRatings({ teaching, attendance, correction, quiz, tCount, aCount, cCount, qCount }: Props) {
   const [detailed, setDetailed] = useState<boolean>(
     typeof window !== 'undefined' && (window as any).showDetailedRatings === true
   );
@@ -130,7 +132,7 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
               <RatingWidget rating={correction} />
 
               <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
-              
+
             </div>
             {typeof cCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
@@ -138,6 +140,23 @@ export default function FacultyRatings({ teaching, attendance, correction, tCoun
                   <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
                 </svg>
                 {cCount}
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col items-center gap-1">
+            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
+              <RatingWidget rating={quiz} />
+
+              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
+
+            </div>
+            {typeof qCount === 'number' && (
+              <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
+                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                  <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
+                </svg>
+                {qCount}
               </span>
             )}
           </div>

--- a/src/components/FixedCardLayout.tsx
+++ b/src/components/FixedCardLayout.tsx
@@ -11,7 +11,7 @@ export function FacultyCardExample() {
       />
       <h3 className="text-lg font-semibold font-poppins">Prof. Jane Doe</h3>
       <p className="text-sm italic text-gray-500">Computer Science</p>
-      <FacultyRatings teaching={4.5} attendance={4.2} correction={4.7} />
+      <FacultyRatings teaching={4.5} attendance={4.2} correction={4.7} quiz={4.0} qCount={20} />
     </div>
   );
 }

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -277,9 +277,11 @@ export default function SearchBar() {
                 teaching={item.teaching_rating ?? 0}
                 attendance={item.attendance_rating ?? 0}
                 correction={item.correction_rating ?? 0}
+                quiz={item.quiz_rating ?? 0}
                 tCount={item.total_ratings ?? null}
                 aCount={item.total_ratings ?? null}
                 cCount={item.total_ratings ?? null}
+                qCount={item.total_ratings ?? null}
               />
             </div>
             <RateFaculty />


### PR DESCRIPTION
## Summary
- support an optional `qCount` in `FacultyRatings`
- display quiz rating count under the Quiz box
- pass through quiz count in card and search components
- show a sample quiz count in the example layout

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dbc91a8c4832fb2de52a645a855b5