### PR TITLE
Adjust faculty card rating labels

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -98,10 +98,8 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
           <div className="flex flex-col items-center gap-1">
             <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
               <RatingWidget rating={teaching} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
-              
             </div>
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
             {typeof tCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -115,10 +113,8 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
           <div className="flex flex-col items-center gap-1">
             <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
               <RatingWidget rating={attendance} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
-              
             </div>
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
             {typeof aCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -132,10 +128,8 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
           <div className="flex flex-col items-center gap-1">
             <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
               <RatingWidget rating={correction} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
-
             </div>
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
             {typeof cCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -149,11 +143,9 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
           <div className="flex flex-col items-center gap-1">
             <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
               <RatingWidget rating={quiz} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
-
             </div>
- 
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
+
             {typeof qCount === 'number' && (
               <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
                 <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## Summary
- move rating headers below rating boxes on FacultyCard

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2bfe348832faeebab31270f05f6