### PR TITLE
Adjust faculty card rating counts

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -96,73 +96,63 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
         <div className="grid grid-cols-2 gap-2 mb-2 w-full text-center">
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
+            <div className={`relative px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof teaching === 'number' ? teaching : 0)}`}>
               <RatingWidget rating={teaching} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
-              
+              {typeof tCount === 'number' && (
+                <span className="absolute right-1 top-1 text-xs text-gray-500 flex items-center gap-1">
+                  <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
+                  </svg>
+                  {tCount}
+                </span>
+              )}
             </div>
-            {typeof tCount === 'number' && (
-              <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
-                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
-                </svg>
-                {tCount}
-              </span>
-            )}
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Teaching</span>
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
+            <div className={`relative px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof attendance === 'number' ? attendance : 0)}`}>
               <RatingWidget rating={attendance} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
-              
+              {typeof aCount === 'number' && (
+                <span className="absolute right-1 top-1 text-xs text-gray-500 flex items-center gap-1">
+                  <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
+                  </svg>
+                  {aCount}
+                </span>
+              )}
             </div>
-            {typeof aCount === 'number' && (
-              <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
-                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
-                </svg>
-                {aCount}
-              </span>
-            )}
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Attendance</span>
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
+            <div className={`relative px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof correction === 'number' ? correction : 0)}`}>
               <RatingWidget rating={correction} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
-
+              {typeof cCount === 'number' && (
+                <span className="absolute right-1 top-1 text-xs text-gray-500 flex items-center gap-1">
+                  <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
+                  </svg>
+                  {cCount}
+                </span>
+              )}
             </div>
-            {typeof cCount === 'number' && (
-              <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
-                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
-                </svg>
-                {cCount}
-              </span>
-            )}
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Correction</span>
           </div>
 
           <div className="flex flex-col items-center gap-1">
-            <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
+            <div className={`relative px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
               <RatingWidget rating={quiz} />
-
-              <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
-
+              {typeof qCount === 'number' && (
+                <span className="absolute right-1 top-1 text-xs text-gray-500 flex items-center gap-1">
+                  <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
+                  </svg>
+                  {qCount}
+                </span>
+              )}
             </div>
- 
-            {typeof qCount === 'number' && (
-              <span className="text-xs text-gray-500 flex items-center gap-1 mt-1">
-                <svg className="w-3 h-3 text-gray-400" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-                  <path d="M2 11a1 1 0 112 0v6a1 1 0 11-2 0v-6zm5-5a1 1 0 112 0v11a1 1 0 11-2 0V6zm5 8a1 1 0 112 0v3a1 1 0 11-2 0v-3zm5-10a1 1 0 112 0v13a1 1 0 11-2 0V4z" />
-                </svg>
-                {qCount}
-              </span>
-            )}
- 
+            <span className="text-sm text-gray-500 dark:text-inherit font-segoe">Quiz</span>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- move rating counts inside each rating box so icon and count display on the box's right side

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2bfe348832faeebab31270f05f6