### PR TITLE
Fix quiz rating alignment

### DIFF
--- a/src/components/FacultyRatings.tsx
+++ b/src/components/FacultyRatings.tsx
@@ -146,7 +146,7 @@ export default function FacultyRatings({ teaching, attendance, correction, quiz,
             )}
           </div>
 
-          <div className="flex flex-col items-center gap-1">
+          <div className="flex flex-col items-center gap-1 col-start-2">
             <div className={`px-2 py-1 md:py-0.5 dark:py-0.5 rounded-lg bg-gray-200 flex flex-col items-center gap-1 shadow w-full dark:justify-center dark:bg-transparent dark:border-2 ${getBoxDarkClasses(typeof quiz === 'number' ? quiz : 0)}`}>
               <RatingWidget rating={quiz} />
 


### PR DESCRIPTION
## Summary
- center the quiz rating box within its row

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dcbbfd060832f9746f8be5c238da6