### PR TITLE
Add divider line and darker bottom for faculty card

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -53,7 +53,8 @@ const quizCount =
         )}
       </div>
     </div>
-    <div class="mb-4">
+    <hr class="border-t border-gray-300 dark:border-gray-700 my-2" />
+    <div class="mb-4 p-2 bg-gray-50 dark:bg-gray-800/40 rounded-md">
       <FacultyRatings
         teaching={faculty.teaching_rating ?? faculty.teachingRating}
         attendance={faculty.attendance_rating ?? faculty.attendanceRating}

--- a/src/components/FacultyCardReact.tsx
+++ b/src/components/FacultyCardReact.tsx
@@ -72,7 +72,8 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
           )}
         </div>
       </div>
-      <div className="mb-4">
+      <hr className="border-t border-gray-300 dark:border-gray-700 my-2" />
+      <div className="mb-4 p-2 bg-gray-50 dark:bg-gray-800/40 rounded-md">
         <FacultyRatings
           teaching={(faculty as any).teaching_rating ?? (faculty as any).teachingRating}
           attendance={(faculty as any).attendance_rating ?? (faculty as any).attendanceRating}


### PR DESCRIPTION
## Summary
- visually separate faculty card halves with a divider
- shade the bottom portion slightly darker

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684dced1ebdc832fa17100a5834fddef