### PR TITLE
Add light grey bottom on faculty card

### DIFF
--- a/src/components/FacultyCard.astro
+++ b/src/components/FacultyCard.astro
@@ -28,6 +28,8 @@ const correctionCount =
 const quizCount =
   faculty.num_quiz_ratings ?? faculty.numQuizRatings ?? faculty.ratingsCount ?? faculty.total_ratings ?? null;
 
+const uid = faculty.id || Math.random().toString(36).slice(2, 8);
+
 ---
 <article class="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6">
     <div class="flex items-start gap-4 mb-2 h-40 dark:h-auto">
@@ -53,7 +55,13 @@ const quizCount =
         )}
       </div>
     </div>
-    <div class="mb-4">
+    <hr class="border-t border-gray-300 dark:border-gray-700 my-2" />
+    <div class="flex gap-2 mb-2">
+      <button type="button" id={`c-${uid}`} class="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">Change</button>
+      <button type="button" id={`l-${uid}`} class="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">Lighter</button>
+      <button type="button" id={`d-${uid}`} class="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">Darker</button>
+    </div>
+    <div id={`b-${uid}`} class="mb-4 p-2 rounded-md bg-gray-100 dark:bg-gray-800/40">
       <FacultyRatings
         teaching={faculty.teaching_rating ?? faculty.teachingRating}
         attendance={faculty.attendance_rating ?? faculty.attendanceRating}
@@ -69,3 +77,30 @@ const quizCount =
     <RateFaculty client:visible />
     <HeartButton faculty={faculty} client:visible />
 </article>
+<script>
+  {
+    const bottom = document.getElementById(`b-${uid}`);
+    const changeBtn = document.getElementById(`c-${uid}`);
+    const lightBtn = document.getElementById(`l-${uid}`);
+    const darkBtn = document.getElementById(`d-${uid}`);
+    let h = 210, s = 20, l = 95;
+    const update = () => {
+      if (bottom) bottom.style.backgroundColor = `hsl(${h}, ${s}%, ${l}%)`;
+    };
+    changeBtn?.addEventListener('click', () => {
+      h = Math.floor(Math.random() * 360);
+      s = 30;
+      update();
+    });
+    lightBtn?.addEventListener('click', () => {
+      l = Math.min(l + 5, 100);
+      update();
+    });
+    darkBtn?.addEventListener('click', () => {
+      l = Math.max(l - 5, 0);
+      update();
+    });
+    update();
+  }
+</script>
+

--- a/src/components/FacultyCardReact.tsx
+++ b/src/components/FacultyCardReact.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import FacultyRatings from './FacultyRatings.tsx';
 import RateFaculty from './RateFaculty.tsx';
 import HeartButton from './HeartButton.tsx';
@@ -45,6 +46,24 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
     (faculty as any).total_ratings ??
     null;
 
+  const [color, setColor] = useState('hsl(210, 20%, 95%)');
+  const lighten = () =>
+    setColor((c) => {
+      const match = /hsl\(\d+, \d+%, (\d+)%\)/.exec(c);
+      const l = match ? parseInt(match[1], 10) : 95;
+      return `hsl(210, 20%, ${Math.min(l + 5, 100)}%)`;
+    });
+  const darken = () =>
+    setColor((c) => {
+      const match = /hsl\(\d+, \d+%, (\d+)%\)/.exec(c);
+      const l = match ? parseInt(match[1], 10) : 95;
+      return `hsl(210, 20%, ${Math.max(l - 5, 0)}%)`;
+    });
+  const change = () => {
+    const h = Math.floor(Math.random() * 360);
+    setColor(`hsl(${h}, 30%, 90%)`);
+  };
+
   return (
     <article className="card pb-32 dark:pb-6 card-wrapper dark:backdrop-blur-lg dark:bg-opacity-5 dark:border dark:border-opacity-20 dark:rounded-2xl dark:p-6">
       <div className="flex items-start gap-4 mb-2 h-40 dark:h-auto">
@@ -72,7 +91,19 @@ export default function FacultyCardReact({ faculty }: { faculty: Faculty }) {
           )}
         </div>
       </div>
-      <div className="mb-4">
+      <hr className="border-t border-gray-300 dark:border-gray-700 my-2" />
+      <div className="flex gap-2 mb-2">
+        <button type="button" onClick={change} className="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">
+          Change
+        </button>
+        <button type="button" onClick={lighten} className="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">
+          Lighter
+        </button>
+        <button type="button" onClick={darken} className="px-2 py-1 text-xs rounded bg-gray-200 dark:bg-gray-700">
+          Darker
+        </button>
+      </div>
+      <div className="mb-4 p-2 rounded-md" style={{ backgroundColor: color }}>
         <FacultyRatings
           teaching={(faculty as any).teaching_rating ?? (faculty as any).teachingRating}
           attendance={(faculty as any).attendance_rating ?? (faculty as any).attendanceRating}


### PR DESCRIPTION
## Summary
- make bottom section of FacultyCard slightly darker with a light grey background
- add buttons to change, lighten, or darken the bottom color

## Testing
- `npm install`
- `npm run build` *(fails to fetch data from supabase but build completes)*

------
https://chatgpt.com/codex/tasks/task_e_684dced1ebdc832fa17100a5834fddef